### PR TITLE
use local typescript instead of global typescript executable

### DIFF
--- a/ref_impl/package-lock.json
+++ b/ref_impl/package-lock.json
@@ -64,6 +64,11 @@
             "requires": {
                 "has-flag": "^3.0.0"
             }
+        },
+        "typescript": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.3.tgz",
+            "integrity": "sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ=="
         }
     }
 }

--- a/ref_impl/package-lock.json
+++ b/ref_impl/package-lock.json
@@ -66,9 +66,10 @@
             }
         },
         "typescript": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.3.tgz",
-            "integrity": "sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ=="
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.4.tgz",
+            "integrity": "sha512-xt5RsIRCEaf6+j9AyOBgvVuAec0i92rgCaS3S+UVf5Z/vF2Hvtsw08wtUTJqp4djwznoAgjSxeCcU4r+CcDBJA==",
+            "dev": true
         }
     }
 }

--- a/ref_impl/package.json
+++ b/ref_impl/package.json
@@ -11,11 +11,11 @@
         "url": "https://github.com/Microsoft/BosqueLanguage"
     },
     "dependencies": {
-        "@types/node": "~10.12.18",
-        "typescript": "^3.4.3"
+        "@types/node": "~10.12.18"
     },
     "devDependencies": {
-        "chalk": "~2.4.2"
+        "chalk": "~2.4.2",
+        "typescript": "^3.4.4"
     },
     "scripts": {
         "build": "./node_modules/.bin/tsc -p tsconfig.json",

--- a/ref_impl/package.json
+++ b/ref_impl/package.json
@@ -11,14 +11,15 @@
         "url": "https://github.com/Microsoft/BosqueLanguage"
     },
     "dependencies": {
-        "@types/node": "~10.12.18"
+        "@types/node": "~10.12.18",
+        "typescript": "^3.4.3"
     },
     "devDependencies": {
         "chalk": "~2.4.2"
     },
     "scripts": {
-        "build": "tsc -p tsconfig.json",
-        "test": "tsc -p tsconfig.json && node ./bin/test/test_runner.js"
+        "build": "./node_modules/.bin/tsc -p tsconfig.json",
+        "test": "./node_modules/.bin/tsc -p tsconfig.json && node ./bin/test/test_runner.js"
     },
     "files": [
         "bin/*"


### PR DESCRIPTION
I think it will be better if we use explicit local typescript executable that can be installed locally, so the user doesn't have to install a system wide typescript which more than often involves administrator/root permission requirement.

This patch should work fine with all Build & Test command as well.