### PR TITLE
Change sample index in section 5.9

### DIFF
--- a/docs/language/overview.md
+++ b/docs/language/overview.md
@@ -715,7 +715,7 @@ Examples of these include:
 var t = @[ 1, 2, 3 ];
 
 t[0]         //1
-t?[1]        //1
+t?[0]        //1
 t[101]       //none
 t@[1]        //@[2]
 t@[2, 0]     //@[3, 1]


### PR DESCRIPTION
Previously accessing index 1 yields value of index 0. Change index instead of result to be consistent with other access-operator sections.