### PR TITLE
Cleanup: Trimmed unnecessary empty lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For a look at how the language works and flows _in the large_ please see the cod
 
 Add 2 numbers:
 
-```none
+```js
 function add2(x: Int, y: Int): Int {
     return x + y;
 }
@@ -33,7 +33,7 @@ add2(2, 3) //5
 
 All odd check using rest parameters and lambda:
 
-```none
+```js
 function allOdd(...args: List[Int]): Bool {
     return args->all(fn(x) => x % 2 == 1);
 }
@@ -43,7 +43,7 @@ allOdd(1, 3, 4) //false
 
 Bulk update properties on Record
 
-```none
+```js
 function update(point: {x: Int, y: Int, z: Int}, value: Int): {x: Int, y: Int, z: Int} {
     return point<~(y=value, x=-point.x);
 }
@@ -53,7 +53,7 @@ update(@{x=1, y=2, z=3}, 5) //@{x=-1, y=5, z=3}
 
 Noneable access on optional argument:
 
-```none
+```js
 function tryGetProperty(r?: {f: Int, k: Int}): Int? {
     return r?.f;
 }
@@ -61,7 +61,7 @@ function tryGetProperty(r?: {f: Int, k: Int}): Int? {
 
 Sign (with optional argument):
 
-```none
+```js
 function sign(x?: Int): Int {
     var! y;
 
@@ -93,7 +93,7 @@ In order to build the language for Windows the following are needed:
 
 The `ref_impl` directory contains the reference implementation parser, type checker, interpreter, and command line runner. In this directory, build and test the Bosque reference implementation with:
 
-```none
+```
 npm install && npm run-script build && npm test
 ```
 
@@ -101,7 +101,7 @@ npm install && npm run-script build && npm test
 
 The `ref_impl` directory contains a simple command line runner for standalone Bosque (`.bsq`) files. These files must have a single `entrypoint` function called `main()` (see [example](ref_impl/src/test/apps/tictactoe/main.bsq)). The code in the file can be parsed, type checked, and executed with:
 
-```none
+```
 node bin/test/app_runner.js FILE.bsq
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ function add2(x: Int, y: Int): Int {
     return x + y;
 }
 
-add2(2, 3) //5
+add2(2, 3) // 5
 ```
 
 All odd check using rest parameters and lambda:
@@ -38,7 +38,7 @@ function allOdd(...args: List[Int]): Bool {
     return args->all(fn(x) => x % 2 == 1);
 }
 
-allOdd(1, 3, 4) //false
+allOdd(1, 3, 4) // false
 ```
 
 Bulk update properties on Record
@@ -48,7 +48,7 @@ function update(point: {x: Int, y: Int, z: Int}, value: Int): {x: Int, y: Int, z
     return point<~(y=value, x=-point.x);
 }
 
-update(@{x=1, y=2, z=3}, 5) //@{x=-1, y=5, z=3}
+update(@{x=1, y=2, z=3}, 5) // @{x=-1, y=5, z=3}
 ```
 
 Noneable access on optional argument:

--- a/README.md
+++ b/README.md
@@ -23,37 +23,37 @@ For a look at how the language works and flows _in the large_ please see the cod
 
 Add 2 numbers:
 
-```ts
+```none
 function add2(x: Int, y: Int): Int {
     return x + y;
 }
 
-add2(2, 3) // 5
+add2(2, 3) //5
 ```
 
 All odd check using rest parameters and lambda:
 
-```ts
+```none
 function allOdd(...args: List[Int]): Bool {
     return args->all(fn(x) => x % 2 == 1);
 }
 
-allOdd(1, 3, 4) // false
+allOdd(1, 3, 4) //false
 ```
 
 Bulk update properties on Record
 
-```ts
+```none
 function update(point: {x: Int, y: Int, z: Int}, value: Int): {x: Int, y: Int, z: Int} {
     return point<~(y=value, x=-point.x);
 }
 
-update(@{x=1, y=2, z=3}, 5) // @{x=-1, y=5, z=3}
+update(@{x=1, y=2, z=3}, 5) //@{x=-1, y=5, z=3}
 ```
 
 Noneable access on optional argument:
 
-```ts
+```none
 function tryGetProperty(r?: {f: Int, k: Int}): Int? {
     return r?.f;
 }
@@ -61,7 +61,7 @@ function tryGetProperty(r?: {f: Int, k: Int}): Int? {
 
 Sign (with optional argument):
 
-```ts
+```none
 function sign(x?: Int): Int {
     var! y;
 
@@ -93,7 +93,7 @@ In order to build the language for Windows the following are needed:
 
 The `ref_impl` directory contains the reference implementation parser, type checker, interpreter, and command line runner. In this directory, build and test the Bosque reference implementation with:
 
-```
+```none
 npm install && npm run-script build && npm test
 ```
 
@@ -101,7 +101,7 @@ npm install && npm run-script build && npm test
 
 The `ref_impl` directory contains a simple command line runner for standalone Bosque (`.bsq`) files. These files must have a single `entrypoint` function called `main()` (see [example](ref_impl/src/test/apps/tictactoe/main.bsq)). The code in the file can be parsed, type checked, and executed with:
 
-```
+```none
 node bin/test/app_runner.js FILE.bsq
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For a look at how the language works and flows _in the large_ please see the cod
 
 Add 2 numbers:
 
-```js
+```ts
 function add2(x: Int, y: Int): Int {
     return x + y;
 }
@@ -33,7 +33,7 @@ add2(2, 3) // 5
 
 All odd check using rest parameters and lambda:
 
-```js
+```ts
 function allOdd(...args: List[Int]): Bool {
     return args->all(fn(x) => x % 2 == 1);
 }
@@ -43,7 +43,7 @@ allOdd(1, 3, 4) // false
 
 Bulk update properties on Record
 
-```js
+```ts
 function update(point: {x: Int, y: Int, z: Int}, value: Int): {x: Int, y: Int, z: Int} {
     return point<~(y=value, x=-point.x);
 }
@@ -53,7 +53,7 @@ update(@{x=1, y=2, z=3}, 5) // @{x=-1, y=5, z=3}
 
 Noneable access on optional argument:
 
-```js
+```ts
 function tryGetProperty(r?: {f: Int, k: Int}): Int? {
     return r?.f;
 }
@@ -61,7 +61,7 @@ function tryGetProperty(r?: {f: Int, k: Int}): Int? {
 
 Sign (with optional argument):
 
-```js
+```ts
 function sign(x?: Int): Int {
     var! y;
 

--- a/ref_impl/src/core/core.bsq
+++ b/ref_impl/src/core/core.bsq
@@ -157,8 +157,3 @@ typedef Predicate[T] = fn(_: T) -> Bool;
 
 //<summary>Shorthand for transform function types.</summary>
 typedef Transform[T, U] = fn(_: T) -> U;
-
-
-
-
-

--- a/ref_impl/src/test/apps/tictactoe/main.bsq
+++ b/ref_impl/src/test/apps/tictactoe/main.bsq
@@ -149,4 +149,3 @@ entrypoint function main(): Game {
 
     return game;
 }
-


### PR DESCRIPTION
The **core.bsq** and **main.bsq** files were having extra empty lines, which are removed and cleaned-up. In addition to this the main **README.md** file is added with the prettify for the code-blocks using the TS syntax highlighting. 