### PR TITLE
Fix typo & delete comments in JSON files

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,7 +10,7 @@ assignees: ''
 **What problem would this feature solve? Please describe and, if possible, provide an example.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Do you have a proposed solution? If so pleaese share it.**
+**Do you have a proposed solution? If so please share it.**
 A clear and concise description of what you want to happen.
 
 **Describe alternative solutions you've considered**

--- a/bosque-language-tools/language-configuration.json
+++ b/bosque-language-tools/language-configuration.json
@@ -1,15 +1,12 @@
 {
     "comments": {
-        // symbol used for single line comment.
         "lineComment": "//",
     },
-    // symbols used as brackets
     "brackets": [
         ["{", "}"],
         ["[", "]"],
         ["(", ")"]
     ],
-    // symbols that are auto closed when typing
     "autoClosingPairs": [
         ["{", "}"],
         ["[", "]"],
@@ -17,7 +14,6 @@
         ["\"", "\""],
         ["'", "'"]
     ],
-    // symbols that that can be used to surround a selection
     "surroundingPairs": [
         ["{", "}"],
         ["[", "]"],


### PR DESCRIPTION
Comments aren't supported in JSON (see https://stackoverflow.com/questions/244777/can-comments-be-used-in-json).