### PR TITLE
Multiline comments

### DIFF
--- a/bosque-language-tools/language-configuration.json
+++ b/bosque-language-tools/language-configuration.json
@@ -1,6 +1,7 @@
 {
     "comments": {
         "lineComment": "//",
+        "blockComment": ["/*", "*/"]
     },
     "brackets": [
         ["{", "}"],

--- a/bosque-language-tools/syntaxes/bosque.tmLanguage.json
+++ b/bosque-language-tools/syntaxes/bosque.tmLanguage.json
@@ -36,6 +36,16 @@
 					"begin": "//",
 					"end": "$",
 					"name": "comment.line.double-dash.bosque"
+				},
+				{
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.comment.bosque"
+						}
+					},
+					"begin": "/\\*",
+					"end": "\\*/",
+					"name": "comment.multiline.double-dash.bosque"
 				}
 			]
 		},

--- a/ref_impl/src/ast/parser.ts
+++ b/ref_impl/src/ast/parser.ts
@@ -249,7 +249,7 @@ class Lexer {
         return true;
     }
 
-    private static readonly _s_commentRe = /\/\/[^\n\r]*/y;
+    private static readonly _s_commentRe = /\/(?:\/[^\n\r]*|\*(?:[^\*]*\**)+?(?<multilineEndChar>\/|\z))/my;
     private tryLexComment(): boolean {
         Lexer._s_commentRe.lastIndex = this.m_cpos;
         const m = Lexer._s_commentRe.exec(this.m_input);
@@ -258,6 +258,11 @@ class Lexer {
         }
 
         this.m_cpos += m[0].length;
+        
+        if (m.groups && m.groups.multilineEndChar !== '/')
+        {
+            return false;
+        }
         return true;
     }
 


### PR DESCRIPTION
Fixes #90.

Changes:
The comment pattern has been changed. It'll capture single line and multi line comments.
VS Code support added.

Testing:
I've written few methods to test the functionality but haven't included in this PR because it's just a workaround. You can see [here](https://github.com/clegoz/BosqueLanguage/commit/59fe05221d0e9e56e480ed34684363ad73aab743)
If there's a way to test the lexer/parser, let me know, I'll be making changes gladly. 