### PR TITLE
Omit js files

### DIFF
--- a/ref_impl/.gitignore
+++ b/ref_impl/.gitignore
@@ -2,3 +2,4 @@
 /bin
 /.vscode
 *.xml
+*.js


### PR DESCRIPTION
   Changes:
When testing .js files are created, which are not needed to be uploaded to the repository. Therefore, we omit them from git.
