### PR TITLE
Add separator to string concat

### DIFF
--- a/ref_impl/src/core/core.bsq
+++ b/ref_impl/src/core/core.bsq
@@ -72,7 +72,7 @@ entity String[unique T] provides Some {
     method trim(): String # string_trim
     method split(token: String): List[String] # string_split
 
-    static concat(...args: List[String]): String # string_concat
+    static concat(separator: String, ...args: List[String]): String # string_concat
 
     //static interpolate(fmt: String, ...args: List[String]): String # string_interpolate
 }

--- a/ref_impl/src/interpreter/builtins.ts
+++ b/ref_impl/src/interpreter/builtins.ts
@@ -87,7 +87,7 @@ const BuiltinCalls = new Map<string, BuiltinCallSig>()
         return createListOf(inv.resultType, splits);
     })
     .set("string_concat", (ep: InterpreterEntryPoint, inv: MIRInvokeDecl, masm: MIRAssembly, args: Map<string, Value>): Value => {
-        return (args.get("args") as ListValue).values.join("");
+        return (args.get("args") as ListValue).values.join(ValueOps.convertToBasicString(args.get("separator")));
     })
 
     .set("float_tryparse", (ep: InterpreterEntryPoint, inv: MIRInvokeDecl, masm: MIRAssembly, args: Map<string, Value>): Value => {


### PR DESCRIPTION
   Changes:
Adds a parameter to string concat to choose the separator.

```
namespace NSMain;

entrypoint function main(): Bool {
    _debug(String::concat(" ", "testing", "this")); // "testing this"
    return true;
}
```

IMO, it's a better design to choose the separator BEFORE dropping the string list to be concatenated.