### PR TITLE
Bugfix: Illegal tokens before the EOF are always getting ignored

### DIFF
--- a/ref_impl/src/ast/parser.ts
+++ b/ref_impl/src/ast/parser.ts
@@ -2023,6 +2023,10 @@ class Parser {
         currentDecl.functions.set(fname, new NamespaceFunctionDecl(sinfo, this.m_penv.getCurrentFile(), attributes, currentDecl.ns, fname, sig));
     }
 
+    private parseEndOfStream() {
+        this.ensureAndConsumeToken(TokenStrings.EndOfStream);
+    }
+
     ////
     //Public methods
 
@@ -2098,8 +2102,8 @@ class Parser {
 
         let usingok = true;
         let parseok = true;
-        while (this.m_cpos < this.m_epos && !this.testToken(TokenStrings.EndOfStream)) {
-            const rpos = this.scanTokenOptions("function", "global", "using", "typedef", "concept", "entity", "enum", "ckey");
+        while (this.m_cpos < this.m_epos) {
+            const rpos = this.scanTokenOptions("function", "global", "using", "typedef", "concept", "entity", "enum", "ckey", TokenStrings.EndOfStream);
 
             try {
                 if (rpos === this.m_epos) {
@@ -2129,6 +2133,9 @@ class Parser {
                 }
                 else if (tk === "entity") {
                     this.parseObject(nsdecl);
+                }
+                else if (tk === TokenStrings.EndOfStream) {
+                    this.parseEndOfStream();
                 }
                 else {
                     //enum or identifier


### PR DESCRIPTION
Fixes #127 

   Changes:
I modified the `parseCompilationUnitPass2()` method in the `Parser` class to handle `EndOfStream` tokens and ensure that there are no illegal tokens.

Note:
I'm not sure if I modified the right method but after examining the `ast/parser.ts` file this one seemed the most appropriate.
