### PR TITLE
Bugfix/lexer current line

### DIFF
--- a/ref_impl/src/ast/parser.ts
+++ b/ref_impl/src/ast/parser.ts
@@ -198,7 +198,7 @@ class Lexer {
     constructor(input: string) {
         this.m_input = input;
         this.m_internTable = new Map<string, string>();
-        this.m_cline = 0;
+        this.m_cline = 1;
         this.m_cpos = 0;
         this.m_tokens = [];
     }


### PR DESCRIPTION
Fixes #148 

   Changes:
Updated `Lexer` constructor so the initial line number is `1` instead of `0`