### PR TITLE
Add test harness for apps as part of unit tests

### DIFF
--- a/ref_impl/src/test/app_tests.ts
+++ b/ref_impl/src/test/app_tests.ts
@@ -1,0 +1,44 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+import { Interpreter } from "../interpreter/interpreter";
+import { TestInfo, TestSet } from "./test_runner";
+import { ValueOps } from "../interpreter/value";
+import { MIRAssembly, PackageConfig } from "../compiler/mir_assembly";
+import { MIREmitter } from "../compiler/mir_emitter";
+
+import * as FS from "fs";
+
+function appTestGenerator(app: string, expected: string): TestSet {
+    const app_tests: TestInfo[] = [
+        { name: "main", input: [], expected: expected }
+    ];
+
+    function setup(core: { relativePath: string, contents: string }[]): { masm: MIRAssembly | undefined, errors: string[] } {
+        const appdata = FS.readFileSync("./src/test/apps/" + app + "/main.bsq").toString();
+
+        const files = core.concat([{ relativePath: "corelib_tests.bsq", contents: appdata }]);
+
+        return MIREmitter.generateMASM(new PackageConfig(), files);
+    }
+
+    function action(assembly: MIRAssembly, args: any[]): any {
+        let ip = new Interpreter(assembly, true, true, true);
+        return ValueOps.diagnosticPrintValue(ip.evaluateRootNamespaceCall("NSMain", "main", args));
+    }
+
+    return { name: app, setup: setup, action: action, tests: app_tests, xmlid: "AppUnitTest_" + app };
+}
+
+const applist = [
+    {app: "angles", expected: "NSMain::Angle@{ degrees=221, primes=1, seconds=0 }"},
+    {app: "max", expected: "20"},
+    {app: "nbody", expected: "-0.16907302171469984"},
+    {app: "tictactoe", expected: "NSMain::Game@{ board=NSMain::Board@{ cells=NSCore::List[T=NSCore::None|NSCore::String[NSMain::PlayerMark]]@{ none, 'o'#NSMain::PlayerMark, 'o'#NSMain::PlayerMark, 'x'#NSMain::PlayerMark, 'x'#NSMain::PlayerMark, 'x'#NSMain::PlayerMark, none, none, none } }, winner='x'#NSMain::PlayerMark }"},
+];
+
+const tests = applist.map((entry) => appTestGenerator(entry.app, entry.expected));
+
+export { tests };

--- a/ref_impl/src/test/apps/tictactoe/main.bsq
+++ b/ref_impl/src/test/apps/tictactoe/main.bsq
@@ -5,7 +5,7 @@
 
 //
 //This is a bosque test/benchmark for a tic-tac-toe program.
-//Expected output is: NSMain::Game@{ board=NSMain::Board@{ cells=NSCore::List[T=NSCore::None|NSCore::String[NSCore::Any]]@{ none, 'o'#NSMain::PlayerMark, 'o'#NSMain::PlayerMark, 'x'#NSMain::PlayerMark, 'x'#NSMain::PlayerMark, 'x'#NSMain::PlayerMark, none, none, none } }, winner='x'#NSMain::PlayerMark }
+//Expected output is: NSMain::Game@{ board=NSMain::Board@{ cells=NSCore::List[T=NSCore::None|NSCore::String[NSMain::PlayerMark]]@{ none, 'o'#NSMain::PlayerMark, 'o'#NSMain::PlayerMark, 'x'#NSMain::PlayerMark, 'x'#NSMain::PlayerMark, 'x'#NSMain::PlayerMark, none, none, none } }, winner='x'#NSMain::PlayerMark }
 //
 
 namespace NSMain;

--- a/ref_impl/src/test/basic_evaluation_test.ts
+++ b/ref_impl/src/test/basic_evaluation_test.ts
@@ -1032,7 +1032,7 @@ const expression_tests: TestInfo[] = [
 ];
 
 function expression_setup(core: { relativePath: string, contents: string }[]): { masm: MIRAssembly | undefined, errors: string[] } {
-    const files = core.concat([{ relativePath: "basic_expression_test.fl", contents: expression_test }]);
+    const files = core.concat([{ relativePath: "basic_expression_test.bsq", contents: expression_test }]);
 
     return MIREmitter.generateMASM(new PackageConfig(), files);
 }
@@ -1359,7 +1359,7 @@ const statement_tests: TestInfo[] = [
 ];
 
 function statement_setup(core: { relativePath: string, contents: string }[]): { masm: MIRAssembly | undefined, errors: string[] } {
-    const files = core.concat([{ relativePath: "basic_statement_test.fl", contents: statement_test }]);
+    const files = core.concat([{ relativePath: "basic_statement_test.bsq", contents: statement_test }]);
 
     return MIREmitter.generateMASM(new PackageConfig(), files);
 }

--- a/ref_impl/src/test/library_tests.ts
+++ b/ref_impl/src/test/library_tests.ts
@@ -110,7 +110,7 @@ const corelib_tests: TestInfo[] = [
 ];
 
 function corelib_setup(core: { relativePath: string, contents: string }[]): { masm: MIRAssembly | undefined, errors: string[] } {
-    const files = core.concat([{ relativePath: "corelib_tests.fl", contents: corelib_test }]);
+    const files = core.concat([{ relativePath: "corelib_tests.bsq", contents: corelib_test }]);
 
     return MIREmitter.generateMASM(new PackageConfig(), files);
 }
@@ -151,7 +151,7 @@ const collectionlib_tests: TestInfo[] = [
 ];
 
 function collectionlib_setup(core: { relativePath: string, contents: string }[]): { masm: MIRAssembly | undefined, errors: string[] } {
-    const files = core.concat([{ relativePath: "collectionlib_tests.fl", contents: collectionlib_test }]);
+    const files = core.concat([{ relativePath: "collectionlib_tests.bsq", contents: collectionlib_test }]);
 
     return MIREmitter.generateMASM(new PackageConfig(), files);
 }

--- a/ref_impl/src/test/regression_tests.ts
+++ b/ref_impl/src/test/regression_tests.ts
@@ -48,7 +48,7 @@ const regression_tests: TestInfo[] = [
 ];
 
 function regression_setup(core: { relativePath: string, contents: string }[]): { masm: MIRAssembly | undefined, errors: string[] } {
-    const files = core.concat([{ relativePath: "regression_tests.fl", contents: regression_test }]);
+    const files = core.concat([{ relativePath: "regression_tests.bsq", contents: regression_test }]);
 
     return MIREmitter.generateMASM(new PackageConfig(), files);
 }

--- a/ref_impl/src/test/test_runner.ts
+++ b/ref_impl/src/test/test_runner.ts
@@ -7,6 +7,8 @@ import * as BasicExpresion from "./basic_evaluation_test";
 import * as Libraries from "./library_tests";
 import * as Regressions from "./regression_tests";
 
+import * as Apps from "./app_tests";
+
 import * as FS from "fs";
 import chalk from "chalk";
 import { RuntimeError } from "../interpreter/interpreter_environment";
@@ -153,10 +155,12 @@ function runAll() {
 
     runner.addSet(Regressions.testRegression);
 
+    Apps.tests.forEach((test) => runner.addSet(test));
+
     runner.run();
 }
 
-export { runAll, TestInfo };
+export { runAll, TestInfo, TestSet };
 
 ////
 //Entrypoint


### PR DESCRIPTION
Changes:
Add unit test harness for running apps (and with different arguments) as part of standard suite.
