### PR TITLE
Tweak equality and collections now stable on *insertion order*

### DIFF
--- a/bosque-language-tools/syntaxes/bosque.tmLanguage.json
+++ b/bosque-language-tools/syntaxes/bosque.tmLanguage.json
@@ -99,7 +99,7 @@
 				},
 				{
 					"name": "keyword.bosque",
-					"match": "\\b(this|hidden|factory|virtual|abstract|override|concept|const|enum|entity|ensures|field|fn|from|function|global|ckey|invariant|method|namespace|provides|requires|static|typedef|unique|using|var|when|where)\\b"
+					"match": "\\b(this|hidden|factory|virtual|abstract|override|concept|const|enum|entity|ensures|field|fn|from|function|global|identifier|invariant|method|namespace|provides|requires|static|typedef|unique|using|var|when|where)\\b"
 				}
 			]
 		},

--- a/docs/language/overview.md
+++ b/docs/language/overview.md
@@ -236,7 +236,7 @@ As a result of these design choices there is always a single _unique_ and _canon
 Equality is a multifaceted concept in programming and ensuring consistent behavior across the many areas it can surface in a modern programming language such as `==`, `.equals`, `Set.has`, `List.sort`, is a source of subtle bugs.
 This complexity further manifests itself in the need to consider the possible aliasing relations of values, in addition to their structural data, in order to understand the behavior of a block of code. The fact that _reference equality_ is chosen as a default, or is an option, is also a bit of an anachronism as reference equality heavily ties the execution to a hardware model in which objects are associated with a memory location.
 
-In light of these issues the Bosque language does not allow user visible _reference equality_ in any operation including `==` or container operations. Instead equality is defined either by the core language for the primitives `Bool`, `Int`, `String`, `GUID`, etc., or as a user defined _composite key_ `ckey` type ([5.21 Equality Comparison](#5.21-Equality-Comparison)). The composite key type allows a developer to create a distinct type to represent a composite equality comparable value that provides the notion of equality e.g. identity, primary key, equivalence, etc. that makes sense for their domain. The language also allows types to define a key field that will be used for equality/order by the associative containers in the language ([3 Collections](#3-Collections)).
+In light of these issues the Bosque language does not allow user visible _reference equality_ in any operation including `==` or container operations. Instead equality is defined either by the core language for the primitives `Bool`, `Int`, `String`, `GUID`, etc., or as a user defined _composite key_ `identifier` type ([5.21 Equality Comparison](#5.21-Equality-Comparison)). The composite key type allows a developer to create a distinct type to represent a composite equality comparable value that provides the notion of equality e.g. identity, primary key, equivalence, etc. that makes sense for their domain. The language also allows types to define a key field that will be used for equality/order by the associative containers in the language ([3 Collections](#3-Collections)).
 
 ## <a name="0.12-Errors-and-Checks"></a>0.12 Errors and Checks
 
@@ -509,7 +509,7 @@ The nominal type system is a mostly standard _object-oriented_ design with param
 
 Users can define abstract types ([TODO]()), `concept` declarations, which allow both abstract definitions and inheritable implementations for `const` members ([TODO]()), `static` functions ([TODO]()), `field` members ([TODO]()), and virtual `method` members ([TODO]()). Bosque `concept` types are fully abstract and can never be instantiated concretely. The `entity` types can provide concepts as well as override definitions in them and can be instantiated concretely but can never be further inherited from.
 
-Developers can alias types or create special types ([TODO]()) using `typedef`, `enum`, and `ckey` constructs ([TODO]()).
+Developers can alias types or create special types ([TODO]()) using `typedef`, `enum`, and `identifier` constructs ([TODO]()).
 
 The Bosque core library defines several unique concepts/entities. The `Any` type is an uber type which all others are a subtype of, the `None` and `Some` types are for distinguishing around the unique `none` value, and `Tuple`, `Record`, etc. exist to unify with the structural type system ([section 2](#2-Core-Types)). The language has primitives for `Bool`, `Int`, `String`, etc. as well as the expected set of parametric collection types such as `List[T]` `Map[K, V]` ([section 3](#2-Collections)).
 
@@ -1234,26 +1234,20 @@ Examples of the equality operators on primitive values include:
 false == none              //false
 ```
 
-Bosque _does not_ admit _reference equality_ in any form. A program can either use explicit comparison on a primitive type _or_ a developer can define a custom key that provides the notion of equality e.g. identity, primary key, equivalence, etc. that makes sense for their domain.
+Bosque _does not_ admit _reference equality_ in any form. A program can either use explicit comparison on a primitive type _or_ a developer can define an identifier key that provides the notion of equality e.g. identity, primary key, equivalence, etc. that makes sense for their domain.
 
-Custom keys are compared using the type of the key and the pairwise equality of each field defined in the key.
+Identifier keys are compared using the type of the key and the pairwise equality of each field defined in the key.
 
 ```none
-ckey MyKey {
-    field idx: Int;
-    field category: String;
-}
+identifier MyKey [Int, String];
 
-ckey OtherKey {
-    field idx: Int;
-    field category: String;
-}
+identifier OtherKey Int;
 
-var a = MyKey@{1, "yes"};
-var b = MyKey@{1, "yes"};
-var c = MyKey@{1, "no"};
+var a = MyKey@create(@[1, "yes"]);
+var b = MyKey@create(@[1, "yes"]);
+var c = MyKey@create(@[1, "no"]);
 
-var q = OtherKey@{1, "yes"};
+var q = OtherKey@create(1);
 
 a == a //true
 a == b //true

--- a/ref_impl/src/ast/assembly.ts
+++ b/ref_impl/src/ast/assembly.ts
@@ -223,7 +223,7 @@ class OOPTypeDecl {
             return false;
         }
 
-        return this.name === "List" || this.name === "TreeSet";
+        return this.name === "List" || this.name === "HashSet";
     }
 
     isTypeAMapEntity(): boolean {
@@ -231,7 +231,7 @@ class OOPTypeDecl {
             return false;
         }
 
-        return this.name === "TreeMap";
+        return this.name === "HashMap";
     }
 
     static attributeSetContains(attr: string, attrSet: string[]): boolean {

--- a/ref_impl/src/ast/parser.ts
+++ b/ref_impl/src/ast/parser.ts
@@ -32,7 +32,7 @@ const KeywordStrings = [
     "from",
     "function",
     "global",
-    "ckey",
+    "identifier",
     "if",
     "invariant",
     "method",
@@ -259,7 +259,7 @@ class Lexer {
         }
 
         if (m.groups) {
-            var groups = m.groups;
+            const groups = m.groups;
             if (groups.multiline !== undefined) {
                 for (const char of groups.multiline) {
                     if (char === "\n") {
@@ -267,7 +267,7 @@ class Lexer {
                     }
                 }
             }
-            if (groups.multilineEndChar !== undefined && groups.multilineEndChar !== '/')
+            if (groups.multilineEndChar !== undefined && groups.multilineEndChar !== "/")
             {
                 this.recordLexToken(this.m_cpos, TokenStrings.Error);
             }
@@ -1580,7 +1580,7 @@ class Parser {
                 const assign = this.parseStructuredAssignment(this.getCurrentSrcInfo(), isConst ? "var" : "var!", decls);
                 decls.forEach((dv) => {
                     if (this.m_penv.getCurrentFunctionScope().isVarNameDefined(dv)) {
-                        this.raiseError(line, "Variable name is already defined")
+                        this.raiseError(line, "Variable name is already defined");
                     }
                     this.m_penv.getCurrentFunctionScope().defineLocalVar(dv);
                 });
@@ -1628,7 +1628,7 @@ class Parser {
             const assign = this.parseStructuredAssignment(this.getCurrentSrcInfo(), undefined, decls);
             decls.forEach((dv) => {
                 if (this.m_penv.getCurrentFunctionScope().isVarNameDefined(dv)) {
-                    this.raiseError(line, "Variable name is already defined")
+                    this.raiseError(line, "Variable name is already defined");
                 }
                 this.m_penv.getCurrentFunctionScope().defineLocalVar(dv);
             });
@@ -2170,12 +2170,12 @@ class Parser {
         let parseok = true;
         while (this.m_cpos < this.m_epos) {
             try {
-                this.m_cpos = this.scanTokenOptions("function", "global", "typedef", "concept", "entity", "enum", "ckey");
+                this.m_cpos = this.scanTokenOptions("function", "global", "typedef", "concept", "entity", "enum", "identifier");
                 if (this.m_cpos === this.m_epos) {
                     const tokenIndexBeforeEOF = this.m_cpos - 2;
                     if (tokenIndexBeforeEOF >= 0 && tokenIndexBeforeEOF < this.m_tokens.length) {
                         const tokenBeforeEOF = this.m_tokens[tokenIndexBeforeEOF];
-                        if (tokenBeforeEOF.kind === TokenStrings.Error) { 
+                        if (tokenBeforeEOF.kind === TokenStrings.Error) {
                             this.raiseError(tokenBeforeEOF.line, `Expected */ but found EOF`);
                         }
                     }
@@ -2192,7 +2192,7 @@ class Parser {
 
                     nsdecl.declaredNames.add(ns + "::" + fname);
                 }
-                else if (this.testToken("typedef") || this.testToken("concept") || this.testToken("entity") || this.testToken("enum") || this.testToken("ckey")) {
+                else if (this.testToken("typedef") || this.testToken("concept") || this.testToken("entity") || this.testToken("enum") || this.testToken("identifier")) {
                     this.consumeToken();
                     this.ensureToken(TokenStrings.Type);
                     const tname = this.consumeTokenAndGetValue();
@@ -2232,7 +2232,7 @@ class Parser {
         let usingok = true;
         let parseok = true;
         while (this.m_cpos < this.m_epos) {
-            const rpos = this.scanTokenOptions("function", "global", "using", "typedef", "concept", "entity", "enum", "ckey", TokenStrings.EndOfStream);
+            const rpos = this.scanTokenOptions("function", "global", "using", "typedef", "concept", "entity", "enum", "identifier", TokenStrings.EndOfStream);
 
             try {
                 if (rpos === this.m_epos) {

--- a/ref_impl/src/core/collections.bsq
+++ b/ref_impl/src/core/collections.bsq
@@ -208,44 +208,40 @@ concept Set[T where Indexable] provides Collection[T] {
     virtual static intersection(...args: List[Set[T]]): Set[T] # set_intersection
 }
 
-//<summary>A TreeSet entity.</summary>
-entity TreeSet[T where Indexable] provides Set[T] {
-    override method empty(): Bool # treeset_empty
-    override method size(): Int # treeset_size
-    override method count(p: Predicate[T]): Int # treeset_count
-    override method {when T Indexable} has(v: T): Bool # treeset_has
-    override method any(p: Predicate[T]): Bool # treeset_any
-    override method all(p: Predicate[T]): Bool # treeset_all
-    override method find(p: Predicate[T]): T # treeset_find
-    override method tryFind(p: Predicate[T]): T? # treeset_tryfind
-    override method defaultFind(p: Predicate[T], default: T): T # treeset_defaultfind
-    override method filter(p: Predicate[T]): TreeSet[T] # treeset_filter
-    override method ofType[U where T](): TreeSet[U] # treeset_ofType
-    override method map[U](f: Transform[T, U]): List[U] # treeset_map
-    override method skipMap[U](f: Transform[T, U?]): List[U] # treeset_skipMap
-    override method flatMap[U](f: Transform[T, Collection[U]]): List[U] # treeset_flatMap
-    override method transform(f: Transform[T, T]): List[T] # treeset_transform
-    override method {when T Indexable} project[U](map: Map[T, U]): List[U] # treeset_project
-    override method {when T Int} min(default?: Int): Int # treeset_min
-    override method {when T Int} max(default?: Int): Int # treeset_max
-    override method {when T Int} sum(): Int # treeset_sum
+//<summary>A HashSet entity.</summary>
+entity HashSet[T where Indexable] provides Set[T] {
+    override method empty(): Bool # hashset_empty
+    override method size(): Int # hashset_size
+    override method count(p: Predicate[T]): Int # hashset_count
+    override method {when T Indexable} has(v: T): Bool # hashset_has
+    override method any(p: Predicate[T]): Bool # hashset_any
+    override method all(p: Predicate[T]): Bool # hashset_all
+    override method find(p: Predicate[T]): T # hashset_find
+    override method tryFind(p: Predicate[T]): T? # hashset_tryfind
+    override method defaultFind(p: Predicate[T], default: T): T # hashset_defaultfind
+    override method filter(p: Predicate[T]): HashSet[T] # hashset_filter
+    override method ofType[U where T](): HashSet[U] # hashset_ofType
+    override method map[U](f: Transform[T, U]): List[U] # hashset_map
+    override method skipMap[U](f: Transform[T, U?]): List[U] # hashset_skipMap
+    override method flatMap[U](f: Transform[T, Collection[U]]): List[U] # hashset_flatMap
+    override method transform(f: Transform[T, T]): List[T] # hashset_transform
+    override method {when T Indexable} project[U](map: Map[T, U]): List[U] # hashset_project
+    override method {when T Int} min(default?: Int): Int # hashset_min
+    override method {when T Int} max(default?: Int): Int # hashset_max
+    override method {when T Int} sum(): Int # hashset_sum
 
-    override method unionWith(other: Set[T]): TreeSet[T] # treeset_unionwith
-    override method difference(other: Set[T]): TreeSet[T] # treeset_difference
+    override method unionWith(other: Set[T]): HashSet[T] # hashset_unionwith
+    override method difference(other: Set[T]): HashSet[T] # hashset_difference
 
-    override static union(...args: List[Set[T]]): TreeSet[T] # treeset_union
-    override static intersection(...args: List[TreeSet[T]]): TreeSet[T] # treeset_intersection
+    override static union(...args: List[Set[T]]): HashSet[T] # hashset_union
+    override static intersection(...args: List[HashSet[T]]): HashSet[T] # hashset_intersection
 
-    //<summary>Add a single element to the set -- only available on TreeSet for performance.</summary>
-    method add(...elems: Collection[T]): TreeSet[T] # treeset_add
+    //<summary>Add a single element to the set -- only available on HashSet for performance.</summary>
+    method add(...elems: Collection[T]): HashSet[T] # hashset_add
 }
 
-//<summary>A HashSet entity.</summary>
-//entity HashSet[T where Indexable] provides Set[T] {
-//}
-
-//<summary>A SortedSet entity.</summary>
-//entity SortedSet[T where Indexable] provides Set[T] {
+//<summary>A CompactSet entity.</summary>
+//entity CompactSet[T where Indexable] provides Set[T] {
 //}
 
 //<summary>A Map concept.</summary>
@@ -338,46 +334,42 @@ concept Map[K where Indexable, V] provides Object {
     virtual static intersection(...args: List[Map[K, V]]): Map[K, V] # map_intersection
 }
 
-//<summary>A TreeMap entity.</summary>
-entity TreeMap[K where Indexable, V] provides Map[K, V] {
-    override method empty(): Bool # treemap_empty
-    override method size(): Int # treemap_size
-    override method has(k: K): Bool # treemap_haskey
-    override method {when V Indexable} hasEntry(entry: [K, V]): Bool # treemap_has
-    override method get(k: K): V # treemap_get
-    override method tryGet(k: K): V? # treemap_tryget
-    override method defaultGet(k: K, default: V): V # treemap_defaultget
-    override method entries(): List[[K, V]] # treemap_entries
-    override method keys(): List[K] # treemap_keys
-    override method values(): List[V] # treemap_values
-    override method count(p: Predicate[[K, V]]): Int # treemap_count
-    override method any(p: Predicate[[K, V]]): Bool # treemap_any
-    override method all(p: Predicate[[K, V]]): Bool # treemap_all
-    override method find(p: Predicate[[K, V]]): [K, V] # treemap_find
-    override method tryFind(p: Predicate[[K, V]]): [K, V]? # treemap_tryfind
-    override method defaultFind(p: Predicate[[K, V]], default: [K, V]): [K, V] # treemap_defaultfind
-    override method filter(p: Predicate[[K, V]]): Map[K, V] # treemap_filter
-    override method ofType[U where K, W where V](): Map[U, W] # treemap_oftype
-    override method map[U where Indexable, W](f: Transform[[K, V], [ U, W ]]): List[[ U, W ]] # treemap_map
-    override method skipMap[U](f: Transform[[K, V], [ U, W ]?]): List[[ U, W ]] # treemap_skipMap
-    override method transform(f: Transform[[K, V], [K, V]]): List[[K, V]] # treemap_transform
-    override method subsetOf(other: Collection[K] | Map[K, V]): Bool # treemap_subsetof
-    override method overlapWith(other: Collection[K] | Map[K, V]): Bool # treemap_overlapwith
-    override method disjointWith(other: Collection[K] | Map[K, V]): Bool # treemap_disjointwith
-    override method unionWith(other: Map[K, V]): Map[K, V] # treemap_unionWith
-    override method difference(other: Collection[K] | Map[K, V]): Map[K, V] # treemap_difference
+//<summary>A HashMap entity.</summary>
+entity HashMap[K where Indexable, V] provides Map[K, V] {
+    override method empty(): Bool # hashmap_empty
+    override method size(): Int # hashmap_size
+    override method has(k: K): Bool # hashmap_haskey
+    override method {when V Indexable} hasEntry(entry: [K, V]): Bool # hashmap_has
+    override method get(k: K): V # hashmap_get
+    override method tryGet(k: K): V? # hashmap_tryget
+    override method defaultGet(k: K, default: V): V # hashmap_defaultget
+    override method entries(): List[[K, V]] # hashmap_entries
+    override method keys(): List[K] # hashmap_keys
+    override method values(): List[V] # hashmap_values
+    override method count(p: Predicate[[K, V]]): Int # hashmap_count
+    override method any(p: Predicate[[K, V]]): Bool # hashmap_any
+    override method all(p: Predicate[[K, V]]): Bool # hashmap_all
+    override method find(p: Predicate[[K, V]]): [K, V] # hashmap_find
+    override method tryFind(p: Predicate[[K, V]]): [K, V]? # hashmap_tryfind
+    override method defaultFind(p: Predicate[[K, V]], default: [K, V]): [K, V] # hashmap_defaultfind
+    override method filter(p: Predicate[[K, V]]): Map[K, V] # hashmap_filter
+    override method ofType[U where K, W where V](): Map[U, W] # hashmap_oftype
+    override method map[U where Indexable, W](f: Transform[[K, V], [ U, W ]]): List[[ U, W ]] # hashmap_map
+    override method skipMap[U](f: Transform[[K, V], [ U, W ]?]): List[[ U, W ]] # hashmap_skipMap
+    override method transform(f: Transform[[K, V], [K, V]]): List[[K, V]] # hashmap_transform
+    override method subsetOf(other: Collection[K] | Map[K, V]): Bool # hashmap_subsetof
+    override method overlapWith(other: Collection[K] | Map[K, V]): Bool # hashmap_overlapwith
+    override method disjointWith(other: Collection[K] | Map[K, V]): Bool # hashmap_disjointwith
+    override method unionWith(other: Map[K, V]): Map[K, V] # hashmap_unionWith
+    override method difference(other: Collection[K] | Map[K, V]): Map[K, V] # hashmap_difference
 
-    override static union(...args: List[Map[K, V]]): Map[K, V] # treemap_union
-    override static intersection(...args: List[Map[K, V]]): Map[K, V] # treemap_intersection
+    override static union(...args: List[Map[K, V]]): Map[K, V] # hashmap_union
+    override static intersection(...args: List[Map[K, V]]): Map[K, V] # hashmap_intersection
 
-    //<summary>Add a single element to the set -- only available on TreeMap for performance.</summary>
-    method add(...elems: Collection[[K, V]]): TreeMap[K, V] # treemap_add
+    //<summary>Add a single element to the set -- only available on HashMap for performance.</summary>
+    method add(...elems: Collection[[K, V]]): HashMap[K, V] # hashmap_add
 }
 
-//<summary>A HashMap entity.</summary>
-//entity HashMap[K where Indexable, V] provides Map[K, V] {
-//}
-
-//<summary>A SortedMap entity.</summary>
-//entity SortedMap[K where Indexable, V] provides Map[K, V] {
+//<summary>A CompactMap entity.</summary>
+//entity CompactMap[K where Indexable, V] provides Map[K, V] {
 //}

--- a/ref_impl/src/core/core.bsq
+++ b/ref_impl/src/core/core.bsq
@@ -149,16 +149,16 @@ concept Function provides Some {
 concept Object provides Some {
 }
 
-//<summary>All actual enums implicitly provide this concept.</summary>
-concept Enum provides Object {
+//<summary>All actual enums implicitly provide this.</summary>
+concept Enum provides Some {
 }
 
-//<summary>All actual custom keys implicitly provide this concept.</summary>
-concept CustomKey provides Object {
+//<summary>All actual custom keys implicitly provide this.</summary>
+concept CustomKey provides Some {
 }
 
 //<summary>Types that can be used as equality based keys.</summary>
-typedef KeyType = None | Bool | Int | String | GUID | Enum | CustomKey;
+typedef KeyType = None | Bool | Int | String | GUID | Enum | Tuple | Record | CustomKey;
 
 //<summary>Providing this concept allows for an entity to be compared or stored in a key based container using the key field.</summary>
 concept Keyed[T where KeyType] provides Some {

--- a/ref_impl/src/interpreter/builtins.ts
+++ b/ref_impl/src/interpreter/builtins.ts
@@ -88,8 +88,8 @@ const BuiltinCalls = new Map<string, BuiltinCallSig>()
     })
     .set("string_reverse", (ep: InterpreterEntryPoint, inv: MIRInvokeDecl, masm: MIRAssembly, args: Map<string, Value>): Value => {
         const val = ValueOps.convertToBasicString(args.get("this"));
-        const chars: Array<string> = val.split('').reverse();
-        return chars.join('');
+        const chars: Array<string> = val.split("").reverse();
+        return chars.join("");
     })
     .set("string_upperCase", (ep: InterpreterEntryPoint, inv: MIRInvokeDecl, masm: MIRAssembly, args: Map<string, Value>): Value => {
         return ValueOps.convertToBasicString(args.get("this")).toUpperCase();
@@ -439,7 +439,7 @@ const BuiltinCalls = new Map<string, BuiltinCallSig>()
     .set("list_set", (ep: InterpreterEntryPoint, inv: MIRInvokeDecl, masm: MIRAssembly, args: Map<string, Value>): Value => {
         const idx = args.get("idx") as number;
         const avals = (args.get("this") as ListValue).values;
-        
+
         return createListOf(inv.resultType, [...avals.slice(0, idx), args.get("v"), ...avals.slice(idx + 1)]);
     })
     .set("list_fill", (ep: InterpreterEntryPoint, inv: MIRInvokeDecl, masm: MIRAssembly, args: Map<string, Value>): Value => {
@@ -447,64 +447,52 @@ const BuiltinCalls = new Map<string, BuiltinCallSig>()
 
         return createListOf(inv.resultType, [...avals]);
     })
-
     .set("math_abs", (ep: InterpreterEntryPoint, inv: MIRInvokeDecl, masm: MIRAssembly, args: Map<string, Value>): Value => {
         const n = args.get("n") as FloatValue;
         return new FloatValue(Math.abs(n.value));
     })
-
     .set("math_atan", (ep: InterpreterEntryPoint, inv: MIRInvokeDecl, masm: MIRAssembly, args: Map<string, Value>): Value => {
         const x = args.get("x") as FloatValue;
         return new FloatValue(Math.atan(x.value));
     })
-
     .set("math_atan2", (ep: InterpreterEntryPoint, inv: MIRInvokeDecl, masm: MIRAssembly, args: Map<string, Value>): Value => {
         const x = args.get("x") as FloatValue;
         const y = args.get("y") as FloatValue;
         return new FloatValue(Math.atan2(y.value, x.value));
     })
-    
     .set("math_ceil", (ep: InterpreterEntryPoint, inv: MIRInvokeDecl, masm: MIRAssembly, args: Map<string, Value>): Value => {
         const n = args.get("n") as FloatValue;
         return new FloatValue(Math.ceil(n.value));
     })
-    
     .set("math_cos", (ep: InterpreterEntryPoint, inv: MIRInvokeDecl, masm: MIRAssembly, args: Map<string, Value>): Value => {
         const x = args.get("x") as FloatValue;
         return new FloatValue(Math.cos(x.value));
     })
-
     .set("math_floor", (ep: InterpreterEntryPoint, inv: MIRInvokeDecl, masm: MIRAssembly, args: Map<string, Value>): Value => {
         const n = args.get("n") as FloatValue;
         return new FloatValue(Math.floor(n.value));
     })
-    
     .set("math_log", (ep: InterpreterEntryPoint, inv: MIRInvokeDecl, masm: MIRAssembly, args: Map<string, Value>): Value => {
         const n = args.get("n") as FloatValue;
         return new FloatValue(Math.log(n.value));
     })
-    
     .set("math_pow", (ep: InterpreterEntryPoint, inv: MIRInvokeDecl, masm: MIRAssembly, args: Map<string, Value>): Value => {
         const b = args.get("b") as FloatValue;
         const e = args.get("e") as FloatValue;
         return new FloatValue(Math.pow(b.value, e.value));
     })
-    
     .set("math_round", (ep: InterpreterEntryPoint, inv: MIRInvokeDecl, masm: MIRAssembly, args: Map<string, Value>): Value => {
         const n = args.get("n") as FloatValue;
         return new FloatValue(Math.round(n.value));
     })
-
     .set("math_sin", (ep: InterpreterEntryPoint, inv: MIRInvokeDecl, masm: MIRAssembly, args: Map<string, Value>): Value => {
         const x = args.get("x") as FloatValue;
         return new FloatValue(Math.sin(x.value));
     })
-
     .set("math_sqrt", (ep: InterpreterEntryPoint, inv: MIRInvokeDecl, masm: MIRAssembly, args: Map<string, Value>): Value => {
         const x = args.get("x") as FloatValue;
         return new FloatValue(Math.sqrt(x.value));
     })
-
     .set("math_tan", (ep: InterpreterEntryPoint, inv: MIRInvokeDecl, masm: MIRAssembly, args: Map<string, Value>): Value => {
         const x = args.get("x") as FloatValue;
         return new FloatValue(Math.tan(x.value));

--- a/ref_impl/src/interpreter/interpreter.ts
+++ b/ref_impl/src/interpreter/interpreter.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
-import { Value, TypedStringValue, EntityValueSimple, ValueOps, ListValue, TreeSetValue, TreeMapValue, TupleValue, RecordValue, LambdaValue } from "./value";
+import { Value, TypedStringValue, EntityValueSimple, ValueOps, ListValue, HashSetValue, HashMapValue, TupleValue, RecordValue, LambdaValue } from "./value";
 import { Environment, PrePostError, raiseRuntimeError, FunctionScope, InvariantError, NotImplementedRuntimeError } from "./interpreter_environment";
 import { MIRAssembly, MIRTupleType, MIRTupleTypeEntry, MIRRecordTypeEntry, MIRRecordType, MIREntityType, MIREntityTypeDecl, MIRFieldDecl, MIROOTypeDecl, MIRType, MIRGlobalDecl, MIRConstDecl, MIRFunctionDecl, MIRStaticDecl, MIRConceptTypeDecl, MIRMethodDecl, MIRInvokeDecl, MIRFunctionType } from "../compiler/mir_assembly";
 import { MIRBody, MIROp, MIROpTag, MIRLoadConst, MIRArgument, MIRTempRegister, MIRRegisterArgument, MIRConstantTrue, MIRConstantString, MIRConstantInt, MIRConstantNone, MIRConstantFalse, MIRLoadConstTypedString, MIRAccessNamespaceConstant, MIRAccessConstField, MIRLoadFieldDefaultValue, MIRAccessCapturedVariable, MIRAccessArgVariable, MIRAccessLocalVariable, MIRConstructorPrimary, MIRConstructorPrimaryCollectionEmpty, MIRConstructorPrimaryCollectionSingletons, MIRConstructorPrimaryCollectionCopies, MIRConstructorPrimaryCollectionMixed, MIRConstructorTuple, MIRConstructorRecord, MIRConstructorLambda, MIRCallNamespaceFunction, MIRCallStaticFunction, MIRAccessFromIndex, MIRProjectFromIndecies, MIRAccessFromProperty, MIRAccessFromField, MIRProjectFromProperties, MIRProjectFromFields, MIRProjectFromTypeTuple, MIRProjectFromTypeRecord, MIRProjectFromTypeConcept, MIRModifyWithIndecies, MIRModifyWithProperties, MIRModifyWithFields, MIRStructuredExtendTuple, MIRStructuredExtendRecord, MIRStructuredExtendObject, MIRInvokeKnownTarget, MIRInvokeVirtualTarget, MIRCallLambda, MIRPrefixOp, MIRBinOp, MIRBinCmp, MIRBinEq, MIRRegAssign, MIRVarStore, MIRReturnAssign, MIRJump, MIRJumpCond, MIRJumpNone, MIRVarLifetimeStart, MIRVarLifetimeEnd, MIRCheck, MIRAssert, MIRTruthyConvert, MIRDebug, MIRPhi, MIRVarLocal } from "../compiler/mir_ops";
@@ -153,13 +153,13 @@ class Interpreter {
         if (ootype.name === "List") {
             return new ListValue(ctype, []);
         }
-        else if (ootype.name === "TreeSet") {
-            return TreeSetValue.create(ctype, []);
+        else if (ootype.name === "HashSet") {
+            return HashSetValue.create(ctype, []);
         }
         else {
-            assert(ootype.name === "TreeMap");
+            assert(ootype.name === "HashMap");
 
-            return TreeMapValue.create(ctype, [] as TupleValue[]);
+            return HashMapValue.create(ctype, [] as TupleValue[]);
         }
     }
 
@@ -171,13 +171,13 @@ class Interpreter {
         if (ootype.name === "List") {
             return new ListValue(ctype, args);
         }
-        else if (ootype.name === "TreeSet") {
-            return TreeSetValue.create(ctype, args);
+        else if (ootype.name === "HashSet") {
+            return HashSetValue.create(ctype, args);
         }
         else {
-            assert(ootype.name === "TreeMap");
+            assert(ootype.name === "HashMap");
 
-            return TreeMapValue.create(ctype, args as TupleValue[]);
+            return HashMapValue.create(ctype, args as TupleValue[]);
         }
     }
 
@@ -189,13 +189,13 @@ class Interpreter {
         if (ootype.name === "List") {
             return new ListValue(ctype, args);
         }
-        else if (ootype.name === "TreeSet") {
-            return TreeSetValue.create(ctype, args);
+        else if (ootype.name === "HashSet") {
+            return HashSetValue.create(ctype, args);
         }
         else {
-            assert(ootype.name === "TreeMap");
+            assert(ootype.name === "HashMap");
 
-            return TreeMapValue.create(ctype, args as TupleValue[]);
+            return HashMapValue.create(ctype, args as TupleValue[]);
         }
     }
 
@@ -207,13 +207,13 @@ class Interpreter {
         if (ootype.name === "List") {
             return new ListValue(ctype, args);
         }
-        else if (ootype.name === "TreeSet") {
-            return TreeSetValue.create(ctype, args);
+        else if (ootype.name === "HashSet") {
+            return HashSetValue.create(ctype, args);
         }
         else {
-            assert(ootype.name === "TreeMap");
+            assert(ootype.name === "HashMap");
 
-            return TreeMapValue.create(ctype, args as TupleValue[]);
+            return HashMapValue.create(ctype, args as TupleValue[]);
         }
     }
 

--- a/ref_impl/src/test/basic_evaluation_test.ts
+++ b/ref_impl/src/test/basic_evaluation_test.ts
@@ -135,11 +135,11 @@ function restArgListSimple(...arg: List[Int]): List[Int] {
     return arg;
 }
 
-function restArgSetSimple[T](...arg: TreeSet[T]): TreeSet[T] {
+function restArgSetSimple[T](...arg: HashSet[T]): HashSet[T] {
     return arg;
 }
 
-function restArgMapSimple(...arg: TreeMap[Int, Bool]): TreeMap[Int, Bool] {
+function restArgMapSimple(...arg: HashMap[Int, Bool]): HashMap[Int, Bool] {
     return arg;
 }
 
@@ -420,6 +420,42 @@ entrypoint function eqTypedStringMixedTrue(): Bool {
 
 entrypoint function eqTypedStringMixedFalse(): Bool {
     return 'hello'#Foo == "hi";
+}
+
+entrypoint function eqTupleTrue(): Bool {
+    return @[1, 2] == @[1, 2];
+}
+
+entrypoint function eqTupleFalse(): Bool {
+    return @[1] == @[3];
+}
+
+entrypoint function eqRecordTrue(): Bool {
+    return @{f=2} == @{f=2};
+}
+
+entrypoint function eqRecordFalse(): Bool {
+    return @{f=2, g=5} == @{f=2, g=1};
+}
+
+entrypoint function eqTupleTrue_Mix(): Bool {
+    var tup: [Int, Int, ?:String] = (1 != 0) ? @[1, 2] : @[1, 2, "ok"];
+    return @[1, 2] == tup;
+}
+
+entrypoint function eqTupleFalse_Mix(): Bool {
+    var tup: [Int, Int, ?:String] = (1 == 0) ? @[1, 2] : @[1, 2, "ok"];
+    return @[1, 2] == tup;
+}
+
+entrypoint function eqRecordTrue_Mix(): Bool {
+    var rec: {f:Int, g?:Int} = (1 != 0) ? @{f=2} : @{f=2, g=5};
+    return @{f=2} == rec;
+}
+
+entrypoint function eqRecordFalse_Mix(): Bool {
+    var rec: {f:Int, g?:Int} = (1 == 0) ? @{f=2} : @{f=2, g=5};
+    return @{f=2} == rec;
 }
 
 entrypoint function neqIntTrue(): Bool {
@@ -767,27 +803,27 @@ entrypoint function createListExpando(): List[Int] {
 }
 
 entrypoint function createSet(): Set[Int] {
-    return TreeSet[Int]@{ 1, 2, 3 };
+    return HashSet[Int]@{ 1, 2, 3 };
 }
 
 entrypoint function createSetOverlap(): Set[Int] {
-    return TreeSet[Int]@{ 1, 2, 3, 2 };
+    return HashSet[Int]@{ 1, 2, 3, 2 };
 }
 
 entrypoint function createSetExpando(): Set[Int] {
-    return TreeSet[Int]@{ ...TreeSet[Int]@{ 1 }, 2, ...List[Int]@{ 4, 5 } };
+    return HashSet[Int]@{ ...HashSet[Int]@{ 1 }, 2, ...List[Int]@{ 4, 5 } };
 }
 
 entrypoint function createMap(): Map[Int, Bool] {
-    return TreeMap[Int, Bool]@{ @[ 1, true ], @[ 2, true ] };
+    return HashMap[Int, Bool]@{ @[ 1, true ], @[ 2, true ] };
 }
 
 entrypoint function createMapOverlap(): Map[Int, Bool] {
-    return TreeMap[Int, Bool]@{ @[ 1, true ], @[ 2, false ], @[ 2, true ] };
+    return HashMap[Int, Bool]@{ @[ 1, true ], @[ 2, false ], @[ 2, true ] };
 }
 
 entrypoint function createMapExpando(): Map[Int, Bool] {
-    return TreeMap[Int, Bool]@{ @[ 1, true ], ...TreeMap[Int, Bool]@{ @[ 1, false ], @[ 2, true ] }, @[ 5, true ] };
+    return HashMap[Int, Bool]@{ @[ 1, true ], ...HashMap[Int, Bool]@{ @[ 1, false ], @[ 2, true ] }, @[ 5, true ] };
 }
 
 entrypoint function invokee3func(): Int {
@@ -916,6 +952,14 @@ const expression_tests: TestInfo[] = [
     { name: "eqTypedStringTrue", input: ["eqTypedStringTrue"], expected: "true" },
     { name: "eqTypedStringMixedTrue", input: ["eqTypedStringMixedTrue"], expected: "true" },
     { name: "eqTypedStringMixedFalse", input: ["eqTypedStringMixedFalse"], expected: "false" },
+    { name: "eqTupleTrue", input: ["eqTupleTrue"], expected: "true" },
+    { name: "eqTupleFalse", input: ["eqTupleFalse"], expected: "false" },
+    { name: "eqRecordTrue", input: ["eqRecordTrue"], expected: "true" },
+    { name: "eqRecordFalse", input: ["eqRecordFalse"], expected: "false" },
+    { name: "eqTupleTrue_Mix", input: ["eqTupleTrue_Mix"], expected: "true" },
+    { name: "eqTupleFalse_Mix", input: ["eqTupleFalse_Mix"], expected: "false" },
+    { name: "eqRecordTrue_Mix", input: ["eqRecordTrue_Mix"], expected: "true" },
+    { name: "eqRecordFalse_Mix", input: ["eqRecordFalse_Mix"], expected: "false" },
     { name: "neqIntTrue", input: ["neqIntTrue"], expected: "true" },
     { name: "neqIntFalse", input: ["neqIntFalse"], expected: "false" },
 
@@ -1001,21 +1045,21 @@ const expression_tests: TestInfo[] = [
     { name: "updateObj", input: ["updateObj"], expected: "NSTestExpression::E1@{ f=5, x=false, y=1, z=true }" },
 
     { name: "restCallSimpleArgsList", input: ["restCallSimpleArgsList"], expected: "NSCore::List[T=NSCore::Int]@{ 1, 1, 2 }" },
-    { name: "restCallSimpleArgsSet", input: ["restCallSimpleArgsSet"], expected: "NSCore::TreeSet[T=NSCore::Int]@{ 1, 2, 3, 4 }" },
-    { name: "restCallOverlapArgsSet", input: ["restCallOverlapArgsSet"], expected: "NSCore::TreeSet[T=NSCore::Int]@{ 1, 2, 3 }" },
-    { name: "restCallSimpleArgsMap", input: ["restCallSimpleArgsMap"], expected: "NSCore::TreeMap[K=NSCore::Int, V=NSCore::Bool]@{ @[ 1, false ], @[ 2, true ] }" },
-    { name: "restCallOverlapArgsMap", input: ["restCallOverlapArgsMap"], expected: "NSCore::TreeMap[K=NSCore::Int, V=NSCore::Bool]@{ @[ 1, true ] }" },
+    { name: "restCallSimpleArgsSet", input: ["restCallSimpleArgsSet"], expected: "NSCore::HashSet[T=NSCore::Int]@{ 4, 1, 2, 3 }" },
+    { name: "restCallOverlapArgsSet", input: ["restCallOverlapArgsSet"], expected: "NSCore::HashSet[T=NSCore::Int]@{ 1, 2, 3 }" },
+    { name: "restCallSimpleArgsMap", input: ["restCallSimpleArgsMap"], expected: "NSCore::HashMap[K=NSCore::Int, V=NSCore::Bool]@{ @[ 1, false ], @[ 2, true ] }" },
+    { name: "restCallOverlapArgsMap", input: ["restCallOverlapArgsMap"], expected: "NSCore::HashMap[K=NSCore::Int, V=NSCore::Bool]@{ @[ 1, true ] }" },
     { name: "restCallMixedList1", input: ["restCallMixedList1"], expected: "NSCore::List[T=NSCore::Int]@{ 4, 1, 2, 3 }" },
     { name: "restCallMixedList2", input: ["restCallMixedList2"], expected: "NSCore::List[T=NSCore::Int]@{ 4, 1, 2, 3 }" },
 
     { name: "createList", input: ["createList"], expected: "NSCore::List[T=NSCore::Int]@{ 1, 1, 2 }" },
     { name: "createListExpando", input: ["createListExpando"], expected: "NSCore::List[T=NSCore::Int]@{ 1, 1, 2, 4 }" },
-    { name: "createSet", input: ["createSet"], expected: "NSCore::TreeSet[T=NSCore::Int]@{ 1, 2, 3 }" },
-    { name: "createSetOverlap", input: ["createSetOverlap"], expected: "NSCore::TreeSet[T=NSCore::Int]@{ 1, 2, 3 }" },
-    { name: "createSetExpando", input: ["createSetExpando"], expected: "NSCore::TreeSet[T=NSCore::Int]@{ 1, 2, 4, 5 }" },
-    { name: "createMap", input: ["createMap"], expected: "NSCore::TreeMap[K=NSCore::Int, V=NSCore::Bool]@{ @[ 1, true ], @[ 2, true ] }" },
-    { name: "createMapOverlap", input: ["createMapOverlap"], expected: "NSCore::TreeMap[K=NSCore::Int, V=NSCore::Bool]@{ @[ 1, true ], @[ 2, true ] }" },
-    { name: "createMapExpando", input: ["createMapExpando"], expected: "NSCore::TreeMap[K=NSCore::Int, V=NSCore::Bool]@{ @[ 1, false ], @[ 2, true ], @[ 5, true ] }" },
+    { name: "createSet", input: ["createSet"], expected: "NSCore::HashSet[T=NSCore::Int]@{ 1, 2, 3 }" },
+    { name: "createSetOverlap", input: ["createSetOverlap"], expected: "NSCore::HashSet[T=NSCore::Int]@{ 1, 3, 2 }" },
+    { name: "createSetExpando", input: ["createSetExpando"], expected: "NSCore::HashSet[T=NSCore::Int]@{ 1, 2, 4, 5 }" },
+    { name: "createMap", input: ["createMap"], expected: "NSCore::HashMap[K=NSCore::Int, V=NSCore::Bool]@{ @[ 1, true ], @[ 2, true ] }" },
+    { name: "createMapOverlap", input: ["createMapOverlap"], expected: "NSCore::HashMap[K=NSCore::Int, V=NSCore::Bool]@{ @[ 1, true ], @[ 2, true ] }" },
+    { name: "createMapExpando", input: ["createMapExpando"], expected: "NSCore::HashMap[K=NSCore::Int, V=NSCore::Bool]@{ @[ 1, false ], @[ 2, true ], @[ 5, true ] }" },
 
     { name: "invokee3func", input: ["invokee3func"], expected: "4" },
     { name: "invokee4func", input: ["invokee4func"], expected: "false" },


### PR DESCRIPTION
Changes:
Allow tuples and records in equality.
Update ckey to identity and change docs (still not implemented though).
Containers now use hash + equality and are stable on *insertion order*
