### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ In order to build the language the following are needed:
 The `ref_impl` directory contains the reference implementation parser, type checker, interpreter, and command line runner. In this directory, build and test the Bosque reference implementation with:
 
 ```none
-npm install && npm run-script build && npm test
+npm install --production=false && npm run-script build && npm test
 ```
 
 ### Command Line Execution

--- a/README.md
+++ b/README.md
@@ -98,10 +98,14 @@ npm install --production=false && npm run-script build && npm test
 
 ### Command Line Execution
 
-The `ref_impl` directory contains a simple command line runner for standalone Bosque (`.bsq`) files. These files must have a single `entrypoint` function called `main()` (see [some examples](ref_impl/src/test/apps)). The code in the file can be parsed, type checked, and executed with:
-
+The `ref_impl` directory contains a simple command line runner for standalone Bosque (`.bsq`) files. These files must have a single `entrypoint` function called `main()` (see [some examples](ref_impl/src/test/apps)). 
+Firstly you should compile `app_runner.ts`:
 ```none
-node bin/test/app_runner.js FILE.bsq
+tsc --downlevelIteration ref_impl/src/test/app_runner.ts
+```
+The bosque code in the file can be parsed, type checked, and executed with:
+```none
+node ref_impl/src/test/app_runner.js FILE.bsq
 ```
 
 ### Visual Studio Code Integration


### PR DESCRIPTION
Some needed dependencies not being installed when you executing npm install in the ref_impl directory

Changes:
Added `--production=false` flag which resolves the problem locally.
Refactored the app running section.