### PR TITLE
Add directory insensitive use of app_runner

### DIFF
--- a/ref_impl/src/test/app_runner.ts
+++ b/ref_impl/src/test/app_runner.ts
@@ -4,6 +4,7 @@
 //-------------------------------------------------------------------------------------------------------
 
 import * as FS from "fs";
+import * as Path from "path";
 import chalk from "chalk";
 import { Interpreter } from "../interpreter/interpreter";
 import { ValueOps } from "../interpreter/value";
@@ -13,12 +14,14 @@ import { PackageConfig, MIRAssembly } from "../compiler/mir_assembly";
 function runApp(app: string) {
     process.stdout.write("Reading app code...\n");
 
+    let bosque_dir: string = Path.normalize(Path.join(__dirname, "../../"));
+
     let files: { relativePath: string, contents: string }[] = [];
     try {
-        const coredir = "./src/core/core.bsq";
+        const coredir = Path.join(bosque_dir, "src/core/core.bsq");
         const coredata = FS.readFileSync(coredir).toString();
 
-        const collectionsdir = "./src/core/collections.bsq";
+        const collectionsdir = Path.join(bosque_dir, "src/core/collections.bsq");
         const collectionsdata = FS.readFileSync(collectionsdir).toString();
 
         const appdir = app;
@@ -56,7 +59,11 @@ function runApp(app: string) {
     process.exit(0);
 }
 
+if (!process.argv[2]) {
+    process.stdout.write(chalk.red("Error -- Please specify a source file as an argument"));
+    process.exit(1);
+}
+
 ////
 //Entrypoint
-
 setImmediate(() => runApp(process.argv[2]));

--- a/ref_impl/src/test/app_runner.ts
+++ b/ref_impl/src/test/app_runner.ts
@@ -66,4 +66,5 @@ if (!process.argv[2]) {
 
 ////
 //Entrypoint
+
 setImmediate(() => runApp(process.argv[2]));


### PR DESCRIPTION
Changes:

Currently, it seems any attempt to run `bin/test/app_runner.js`  needs to be in the `ref_impl` directory. I wanted to play around with some Bosque files located on my desktop, so I made a PowerShell alias to the compiler so I could just run it from the command line:

![bosque_alias](https://user-images.githubusercontent.com/19238087/58067389-7a7df580-7bd0-11e9-8769-931b401de752.png)

However, using this fails as `app_runner.ts` only looks in the current directory (in this case, the desktop) for the core files:

![bosque_cannot_find_core](https://user-images.githubusercontent.com/19238087/58067438-9ed9d200-7bd0-11e9-9512-e1cacef1e374.png)

This PR makes Bosque look in the correct location regardless of where you call the compiler from, enabling aliases like the one above, so you don't have to fill the `ref_impl` directory with all your own files:

![bosque_working](https://user-images.githubusercontent.com/19238087/58067470-bca73700-7bd0-11e9-80be-8d5d9d67bf12.png)

I also made the argument checking a little nicer for when the source file isn't provided as an argument:

![bosque_better_argument](https://user-images.githubusercontent.com/19238087/58067511-dc3e5f80-7bd0-11e9-93ec-e1feef873b76.png)