### PR TITLE
Add asin and acos functions to Math core

### DIFF
--- a/ref_impl/src/core/core.bsq
+++ b/ref_impl/src/core/core.bsq
@@ -107,6 +107,8 @@ entity Float provides Some, Parsable {
 //<summary>Math helpers</summary>
 entity Math {
     static abs(n: Float): Float # math_abs
+    static acos(x: Float): Float # math_acos
+    static asin(x: Float): Float # math_asin
     static atan(x: Float): Float # math_atan
     static atan2(y: Float, x: Float): Float # math_atan2
     static ceil(n: Float): Float # math_ceil

--- a/ref_impl/src/interpreter/builtins.ts
+++ b/ref_impl/src/interpreter/builtins.ts
@@ -452,6 +452,14 @@ const BuiltinCalls = new Map<string, BuiltinCallSig>()
         const n = args.get("n") as FloatValue;
         return new FloatValue(Math.abs(n.value));
     })
+    .set("math_acos", (ep: InterpreterEntryPoint, inv: MIRInvokeDecl, masm: MIRAssembly, args: Map<string, Value>): Value => {
+        const x = args.get("x") as FloatValue;
+        return new FloatValue(Math.acos(x.value));    
+    })
+    .set("math_asin", (ep: InterpreterEntryPoint, inv: MIRInvokeDecl, masm: MIRAssembly, args: Map<string, Value>): Value => {
+        const x = args.get("x") as FloatValue;
+        return new FloatValue(Math.asin(x.value));    
+    })
     .set("math_atan", (ep: InterpreterEntryPoint, inv: MIRInvokeDecl, masm: MIRAssembly, args: Map<string, Value>): Value => {
         const x = args.get("x") as FloatValue;
         return new FloatValue(Math.atan(x.value));

--- a/ref_impl/src/test/library_tests.ts
+++ b/ref_impl/src/test/library_tests.ts
@@ -17,6 +17,16 @@ entrypoint function mathAbs(): Float {
     return Math::abs(n);
 }
 
+entrypoint function mathAcos(): Float {
+    var x: Float = '0.0'@Float;
+    return Math::acos(x);
+}
+
+entrypoint function mathAsin(): Float {
+    var x: Float = '1.0'@Float;
+    return Math::asin(x);
+}
+
 entrypoint function mathAtan(): Float {
     var x: Float = '3.0'@Float;
     return Math::atan(x);
@@ -92,6 +102,8 @@ entrypoint function literalDownCase(): String {
 
 const corelib_tests: TestInfo[] = [
     { name: "mathAbs", input: ["mathAbs"], expected: "2" },
+    { name: "mathAcos", input: ["mathAcos"], expected: "1.5707963267948966" },
+    { name: "mathAsin", input: ["mathAsin"], expected: "1.5707963267948966" },
     { name: "mathAtan", input: ["mathAtan"], expected: "1.2490457723982544" },
     { name: "mathAtan2", input: ["mathAtan2"], expected: "0.5404195002705842" },
     { name: "mathCeil", input: ["mathCeil"], expected: "7" },


### PR DESCRIPTION
related to #136 

Added arcus functions for sine and cosine to the math helper in core.
