### PR TITLE
Add abort and simplify MIR ops to use it instead

### DIFF
--- a/ref_impl/src/ast/body.ts
+++ b/ref_impl/src/ast/body.ts
@@ -598,6 +598,7 @@ enum StatementTag {
     IfElseStatement = "IfElseStatement",
     MatchStatement = "MatchStatement",
 
+    AbortStatement = "AbortStatement",
     AssertStatement = "AssertStatement", //assert(x > 0)
     CheckStatement = "CheckStatement", //check(x > 0)
 
@@ -774,6 +775,12 @@ class MatchStatement extends Statement {
     }
 }
 
+class AbortStatement extends Statement {
+    constructor(sinfo: SourceInfo) {
+        super(StatementTag.AbortStatement, sinfo);
+    }
+}
+
 class AssertStatement extends Statement {
     readonly cond: Expression;
 
@@ -837,7 +844,7 @@ export {
     VariableDeclarationStatement, VariableAssignmentStatement,
     StructuredAssignment, IgnoreTermStructuredAssignment, ConstValueStructuredAssignment, VariableDeclarationStructuredAssignment, VariableAssignmentStructuredAssignment, TupleStructuredAssignment, RecordStructuredAssignment, StructuredVariableAssignmentStatement,
     ReturnStatement, YieldStatement,
-    IfElseStatement, AssertStatement, CheckStatement, DebugStatement,
+    IfElseStatement, AbortStatement, AssertStatement, CheckStatement, DebugStatement,
     MatchGuard, WildcardMatchGuard, TypeMatchGuard, StructureMatchGuard, MatchEntry, MatchStatement,
     BlockStatement, BodyImplementation
 };

--- a/ref_impl/src/ast/parser.ts
+++ b/ref_impl/src/ast/parser.ts
@@ -5,7 +5,7 @@
 
 import { ParserEnvironment, FunctionScope } from "./parser_env";
 import { FunctionParameter, TypeSignature, NominalTypeSignature, TemplateTypeSignature, ParseErrorTypeSignature, TupleTypeSignature, RecordTypeSignature, FunctionTypeSignature, UnionTypeSignature, IntersectionTypeSignature, AutoTypeSignature } from "./type_signature";
-import { Arguments, TemplateArguments, NamedArgument, PositionalArgument, InvalidExpression, Expression, LiteralNoneExpression, LiteralBoolExpression, LiteralIntegerExpression, LiteralStringExpression, LiteralTypedStringExpression, AccessVariableExpression, AccessNamespaceConstantExpression, LiteralTypedStringConstructorExpression, CallNamespaceFunctionExpression, AccessStaticFieldExpression, ConstructorTupleExpression, ConstructorRecordExpression, ConstructorPrimaryExpression, ConstructorPrimaryWithFactoryExpression, ConstructorLambdaExpression, PostfixOperation, PostfixAccessFromIndex, PostfixAccessFromName, PostfixProjectFromIndecies, PostfixProjectFromNames, PostfixProjectFromType, PostfixModifyWithIndecies, PostfixModifyWithNames, PostfixStructuredExtend, PostfixInvoke, PostfixCallLambda, PostfixOp, PrefixOp, BinOpExpression, BinEqExpression, BinCmpExpression, BinLogicExpression, NonecheckExpression, CoalesceExpression, SelectExpression, BlockStatement, Statement, BodyImplementation, EmptyStatement, InvalidStatement, VariableDeclarationStatement, VariableAssignmentStatement, ReturnStatement, YieldStatement, CondBranchEntry, IfElse, IfElseStatement, InvokeArgument, CallStaticFunctionExpression, AssertStatement, CheckStatement, DebugStatement, StructuredAssignment, TupleStructuredAssignment, RecordStructuredAssignment, VariableDeclarationStructuredAssignment, IgnoreTermStructuredAssignment, VariableAssignmentStructuredAssignment, ConstValueStructuredAssignment, StructuredVariableAssignmentStatement, MatchStatement, MatchEntry, MatchGuard, WildcardMatchGuard, TypeMatchGuard, StructureMatchGuard } from "./body";
+import { Arguments, TemplateArguments, NamedArgument, PositionalArgument, InvalidExpression, Expression, LiteralNoneExpression, LiteralBoolExpression, LiteralIntegerExpression, LiteralStringExpression, LiteralTypedStringExpression, AccessVariableExpression, AccessNamespaceConstantExpression, LiteralTypedStringConstructorExpression, CallNamespaceFunctionExpression, AccessStaticFieldExpression, ConstructorTupleExpression, ConstructorRecordExpression, ConstructorPrimaryExpression, ConstructorPrimaryWithFactoryExpression, ConstructorLambdaExpression, PostfixOperation, PostfixAccessFromIndex, PostfixAccessFromName, PostfixProjectFromIndecies, PostfixProjectFromNames, PostfixProjectFromType, PostfixModifyWithIndecies, PostfixModifyWithNames, PostfixStructuredExtend, PostfixInvoke, PostfixCallLambda, PostfixOp, PrefixOp, BinOpExpression, BinEqExpression, BinCmpExpression, BinLogicExpression, NonecheckExpression, CoalesceExpression, SelectExpression, BlockStatement, Statement, BodyImplementation, EmptyStatement, InvalidStatement, VariableDeclarationStatement, VariableAssignmentStatement, ReturnStatement, YieldStatement, CondBranchEntry, IfElse, IfElseStatement, InvokeArgument, CallStaticFunctionExpression, AssertStatement, CheckStatement, DebugStatement, StructuredAssignment, TupleStructuredAssignment, RecordStructuredAssignment, VariableDeclarationStructuredAssignment, IgnoreTermStructuredAssignment, VariableAssignmentStructuredAssignment, ConstValueStructuredAssignment, StructuredVariableAssignmentStatement, MatchStatement, MatchEntry, MatchGuard, WildcardMatchGuard, TypeMatchGuard, StructureMatchGuard, AbortStatement } from "./body";
 import { Assembly, NamespaceUsing, NamespaceDeclaration, NamespaceTypedef, StaticMemberDecl, StaticFunctionDecl, MemberFieldDecl, MemberMethodDecl, ConceptTypeDecl, EntityTypeDecl, NamespaceConstDecl, NamespaceFunctionDecl, InvokeDecl, TemplateTermDecl, TemplateTermRestriction } from "./assembly";
 
 const KeywordStrings = [
@@ -17,6 +17,7 @@ const KeywordStrings = [
     "entrypoint",
 
     "_debug",
+    "abort",
     "assert",
     "case",
     "check",
@@ -1683,6 +1684,12 @@ class Parser {
 
             this.ensureAndConsumeToken(";");
             return new YieldStatement(sinfo, exp);
+        }
+        else if (tk === "abort") {
+            this.consumeToken();
+
+            this.ensureAndConsumeToken(";");
+            return new AbortStatement(sinfo);
         }
         else if (tk === "assert") {
             this.consumeToken();

--- a/ref_impl/src/compiler/mir_cleanup.ts
+++ b/ref_impl/src/compiler/mir_cleanup.ts
@@ -5,7 +5,7 @@
 
 import * as assert from "assert";
 
-import { MIROp, MIRBody, MIRArgument, MIROpTag, MIRTempRegister, MIRLoadConst, MIRAccessCapturedVariable, MIRAccessArgVariable, MIRAccessLocalVariable, MIRConstructorPrimary, MIRConstructorPrimaryCollectionSingletons, MIRConstructorPrimaryCollectionCopies, MIRConstructorPrimaryCollectionMixed, MIRConstructorTuple, MIRConstructorRecord, MIRCallNamespaceFunction, MIRCallStaticFunction, MIRAccessFromIndex, MIRProjectFromIndecies, MIRAccessFromProperty, MIRProjectFromProperties, MIRAccessFromField, MIRProjectFromFields, MIRProjectFromTypeTuple, MIRProjectFromTypeRecord, MIRProjectFromTypeConcept, MIRModifyWithIndecies, MIRModifyWithProperties, MIRModifyWithFields, MIRStructuredExtendTuple, MIRStructuredExtendRecord, MIRStructuredExtendObject, MIRInvokeKnownTarget, MIRInvokeVirtualTarget, MIRCallLambda, MIRPrefixOp, MIRBinOp, MIRBinEq, MIRBinCmp, MIRRegAssign, MIRTruthyConvert, MIRVarStore, MIRReturnAssign, MIRAssert, MIRCheck, MIRDebug, MIRJumpCond, MIRJumpNone, MIRBasicBlock, MIRIsTypeOfNone, MIRIsTypeOfSome, MIRIsTypeOf, MIRLogicStore } from "./mir_ops";
+import { MIROp, MIRBody, MIRArgument, MIROpTag, MIRTempRegister, MIRLoadConst, MIRAccessCapturedVariable, MIRAccessArgVariable, MIRAccessLocalVariable, MIRConstructorPrimary, MIRConstructorPrimaryCollectionSingletons, MIRConstructorPrimaryCollectionCopies, MIRConstructorPrimaryCollectionMixed, MIRConstructorTuple, MIRConstructorRecord, MIRCallNamespaceFunction, MIRCallStaticFunction, MIRAccessFromIndex, MIRProjectFromIndecies, MIRAccessFromProperty, MIRProjectFromProperties, MIRAccessFromField, MIRProjectFromFields, MIRProjectFromTypeTuple, MIRProjectFromTypeRecord, MIRProjectFromTypeConcept, MIRModifyWithIndecies, MIRModifyWithProperties, MIRModifyWithFields, MIRStructuredExtendTuple, MIRStructuredExtendRecord, MIRStructuredExtendObject, MIRInvokeKnownTarget, MIRInvokeVirtualTarget, MIRCallLambda, MIRPrefixOp, MIRBinOp, MIRBinEq, MIRBinCmp, MIRRegAssign, MIRTruthyConvert, MIRVarStore, MIRReturnAssign, MIRDebug, MIRJumpCond, MIRJumpNone, MIRBasicBlock, MIRIsTypeOfNone, MIRIsTypeOfSome, MIRIsTypeOf, MIRLogicStore } from "./mir_ops";
 
 //
 //Implement cleanup passes for the MIR after translation from the AST representation:
@@ -267,17 +267,7 @@ function propagateTmpAssignForOp(op: MIROp, propMap: Map<number, MIRArgument>) {
             ra.src = propagateTmpAssign_Remap(ra.src, propMap);
             break;
         }
-        case MIROpTag.MIRAssert: {
-            const asrt = op as MIRAssert;
-            asrt.cond = propagateTmpAssign_Remap(asrt.cond, propMap);
-            break;
-        }
-        case MIROpTag.MIRCheck: {
-            const chk = op as MIRCheck;
-            chk.cond = propagateTmpAssign_Remap(chk.cond, propMap);
-            break;
-        }
-        case MIROpTag.MIRExhaustiveCheck: {
+        case MIROpTag.MIRAbort: {
             break;
         }
         case MIROpTag.MIRDebug: {

--- a/ref_impl/src/compiler/mir_emitter.ts
+++ b/ref_impl/src/compiler/mir_emitter.ts
@@ -4,7 +4,7 @@
 //-------------------------------------------------------------------------------------------------------
 
 import { SourceInfo, Parser } from "../ast/parser";
-import { MIRTempRegister, MIROp, MIRLoadConst, MIRConstantNone, MIRConstantTrue, MIRConstantFalse, MIRConstantInt, MIRConstantString, MIRLoadConstTypedString, MIRTypeKey, MIRAccessNamespaceConstant, MIRAccessConstField, MIRConstKey, MIRAccessCapturedVariable, MIRAccessArgVariable, MIRAccessLocalVariable, MIRArgument, MIRLambdaKey, MIRFunctionKey, MIRStaticKey, MIRConstructorPrimary, MIRConstructorPrimaryCollectionSingletons, MIRConstructorPrimaryCollectionCopies, MIRConstructorPrimaryCollectionMixed, MIRMethodKey, MIRGlobalKey, MIRAccessFromIndex, MIRProjectFromIndecies, MIRProjectFromProperties, MIRProjectFromFields, MIRAccessFromProperty, MIRAccessFromField, MIRConstructorTuple, MIRConstructorRecord, MIRConstructorPrimaryCollectionEmpty, MIRResolvedTypeKey, MIRFieldKey, MIRLoadFieldDefaultValue, MIRConstructorLambda, MIRCallNamespaceFunction, MIRCallStaticFunction, MIRProjectFromTypeTuple, MIRProjectFromTypeRecord, MIRProjectFromTypeConcept, MIRModifyWithIndecies, MIRModifyWithProperties, MIRModifyWithFields, MIRStructuredExtendTuple, MIRStructuredExtendRecord, MIRStructuredExtendObject, MIRInvokeKnownTarget, MIRVirtualMethodKey, MIRInvokeVirtualTarget, MIRCallLambda, MIRJump, MIRJumpCond, MIRPrefixOp, MIRBinOp, MIRBinCmp, MIRBinEq, MIRRegAssign, MIRVarStore, MIRReturnAssign, MIRVarLifetimeStart, MIRVarLifetimeEnd, MIRBody, MIRAssert, MIRCheck, MIRBasicBlock, MIRTruthyConvert, MIRJumpNone, MIRDebug, MIRVarCaptured, MIRVarParameter, MIRVarLocal, MIRRegisterArgument, MIRIsTypeOfNone, MIRIsTypeOfSome, MIRIsTypeOf, MIRLogicStore, MIRExhaustiveCheck } from "./mir_ops";
+import { MIRTempRegister, MIROp, MIRLoadConst, MIRConstantNone, MIRConstantTrue, MIRConstantFalse, MIRConstantInt, MIRConstantString, MIRLoadConstTypedString, MIRTypeKey, MIRAccessNamespaceConstant, MIRAccessConstField, MIRConstKey, MIRAccessCapturedVariable, MIRAccessArgVariable, MIRAccessLocalVariable, MIRArgument, MIRLambdaKey, MIRFunctionKey, MIRStaticKey, MIRConstructorPrimary, MIRConstructorPrimaryCollectionSingletons, MIRConstructorPrimaryCollectionCopies, MIRConstructorPrimaryCollectionMixed, MIRMethodKey, MIRGlobalKey, MIRAccessFromIndex, MIRProjectFromIndecies, MIRProjectFromProperties, MIRProjectFromFields, MIRAccessFromProperty, MIRAccessFromField, MIRConstructorTuple, MIRConstructorRecord, MIRConstructorPrimaryCollectionEmpty, MIRResolvedTypeKey, MIRFieldKey, MIRLoadFieldDefaultValue, MIRConstructorLambda, MIRCallNamespaceFunction, MIRCallStaticFunction, MIRProjectFromTypeTuple, MIRProjectFromTypeRecord, MIRProjectFromTypeConcept, MIRModifyWithIndecies, MIRModifyWithProperties, MIRModifyWithFields, MIRStructuredExtendTuple, MIRStructuredExtendRecord, MIRStructuredExtendObject, MIRInvokeKnownTarget, MIRVirtualMethodKey, MIRInvokeVirtualTarget, MIRCallLambda, MIRJump, MIRJumpCond, MIRPrefixOp, MIRBinOp, MIRBinCmp, MIRBinEq, MIRRegAssign, MIRVarStore, MIRReturnAssign, MIRVarLifetimeStart, MIRVarLifetimeEnd, MIRBody, MIRBasicBlock, MIRTruthyConvert, MIRJumpNone, MIRDebug, MIRVarCaptured, MIRVarParameter, MIRVarLocal, MIRRegisterArgument, MIRIsTypeOfNone, MIRIsTypeOfSome, MIRIsTypeOf, MIRLogicStore, MIRAbort } from "./mir_ops";
 import { OOPTypeDecl, StaticFunctionDecl, MemberMethodDecl, InvokeDecl, Assembly, NamespaceFunctionDecl, NamespaceConstDecl, StaticMemberDecl, ConceptTypeDecl, EntityTypeDecl } from "../ast/assembly";
 import { ResolvedType, ResolvedEntityAtomType, ResolvedConceptAtomType, ResolvedTupleAtomType, ResolvedRecordAtomType, ResolvedFunctionAtomType, ResolvedConceptAtomTypeEntry } from "../ast/resolved_type";
 import { PackageConfig, MIRAssembly, MIRType, MIRTypeOption, MIRFunctionType, MIRFunctionParameter, MIREntityType, MIRConceptType, MIRTupleTypeEntry, MIRTupleType, MIRRecordTypeEntry, MIRRecordType } from "./mir_assembly";
@@ -340,20 +340,12 @@ class MIRBodyEmitter {
         this.m_currentBlock.push(new MIRVarLifetimeEnd(sinfo, name));
     }
 
-    emitReturnAssign(sinfo: SourceInfo, src: MIRTempRegister) {
+    emitReturnAssign(sinfo: SourceInfo, src: MIRArgument) {
         this.m_currentBlock.push(new MIRReturnAssign(sinfo, src));
     }
 
-    emitAssert(sinfo: SourceInfo, cond: MIRArgument) {
-        this.m_currentBlock.push(new MIRAssert(sinfo, cond));
-    }
-
-    emitCheck(sinfo: SourceInfo, cond: MIRArgument) {
-        this.m_currentBlock.push(new MIRCheck(sinfo, cond));
-    }
-
-    emitExhaustiveCheck(sinfo: SourceInfo) {
-        this.m_currentBlock.push(new MIRExhaustiveCheck(sinfo));
+    emitAbort(sinfo: SourceInfo, releaseEnable: boolean, info: string) {
+        this.m_currentBlock.push(new MIRAbort(sinfo, releaseEnable, info));
     }
 
     emitDebugBreak(sinfo: SourceInfo) {

--- a/ref_impl/src/compiler/mir_ops.ts
+++ b/ref_impl/src/compiler/mir_ops.ts
@@ -193,9 +193,7 @@ enum MIROpTag {
     MIRVarStore = "MIRVarStore",
     MIRReturnAssign = "MIRReturnAssign",
 
-    MIRAssert = "MIRAssert",
-    MIRCheck = "MIRCheck",
-    MIRExhaustiveCheck = "MIRExhaustiveCheck",
+    MIRAbort = "MIRAbort",
     MIRDebug = "MIRDebug",
 
     MIRJump = "MIRJump",
@@ -1052,7 +1050,7 @@ class MIRReturnAssign extends MIRFlowOp {
     src: MIRArgument;
     name: MIRVarLocal;
 
-    constructor(sinfo: SourceInfo, src: MIRTempRegister) {
+    constructor(sinfo: SourceInfo, src: MIRArgument) {
         super(MIROpTag.MIRReturnAssign, sinfo);
         this.src = src;
         this.name = new MIRVarLocal("_ir_ret_");
@@ -1066,48 +1064,21 @@ class MIRReturnAssign extends MIRFlowOp {
     }
 }
 
-class MIRAssert extends MIRFlowOp {
-    cond: MIRArgument;
+class MIRAbort extends MIRFlowOp {
+    readonly releaseEnable: boolean;
+    readonly info: string;
 
-    constructor(sinfo: SourceInfo, cond: MIRArgument) {
-        super(MIROpTag.MIRAssert, sinfo);
-        this.cond = cond;
-    }
-
-    getUsedVars(): MIRRegisterArgument[] { return varsOnlyHelper([this.cond]); }
-    getModVars(): MIRRegisterArgument[] { return []; }
-
-    stringify(): string {
-        return `assert ${this.cond.stringify()}`;
-    }
-}
-
-class MIRCheck extends MIRFlowOp {
-    cond: MIRArgument;
-
-    constructor(sinfo: SourceInfo, cond: MIRArgument) {
-        super(MIROpTag.MIRCheck, sinfo);
-        this.cond = cond;
-    }
-
-    getUsedVars(): MIRRegisterArgument[] { return varsOnlyHelper([this.cond]); }
-    getModVars(): MIRRegisterArgument[] { return []; }
-
-    stringify(): string {
-        return `check ${this.cond.stringify()}`;
-    }
-}
-
-class MIRExhaustiveCheck extends MIRFlowOp {
-    constructor(sinfo: SourceInfo) {
-        super(MIROpTag.MIRExhaustiveCheck, sinfo);
+    constructor(sinfo: SourceInfo, releaseEnable: boolean, info: string) {
+        super(MIROpTag.MIRAbort, sinfo);
+        this.releaseEnable = releaseEnable;
+        this.info = info;
     }
 
     getUsedVars(): MIRRegisterArgument[] { return []; }
     getModVars(): MIRRegisterArgument[] { return []; }
 
     stringify(): string {
-        return "$ExhaustiveCheck";
+        return `abort${this.releaseEnable ? "" : "_debug"} -- ${this.info}`;
     }
 }
 
@@ -1338,7 +1309,7 @@ export {
     MIRPrefixOp, MIRBinOp, MIRBinEq, MIRBinCmp,
     MIRIsTypeOfNone, MIRIsTypeOfSome, MIRIsTypeOf,
     MIRRegAssign, MIRTruthyConvert, MIRLogicStore, MIRVarStore, MIRReturnAssign,
-    MIRAssert, MIRCheck, MIRExhaustiveCheck, MIRDebug,
+    MIRAbort, MIRDebug,
     MIRJump, MIRJumpCond, MIRJumpNone,
     MIRPhi,
     MIRVarLifetimeStart, MIRVarLifetimeEnd,

--- a/ref_impl/src/compiler/mir_ssa.ts
+++ b/ref_impl/src/compiler/mir_ssa.ts
@@ -4,7 +4,7 @@
 //-------------------------------------------------------------------------------------------------------
 
 import * as assert from "assert";
-import { MIRBody, MIRRegisterArgument, MIRBasicBlock, MIROpTag, MIRJumpNone, MIRJumpCond, MIROp, MIRValueOp, MIRTempRegister, MIRAccessCapturedVariable, MIRAccessArgVariable, MIRArgument, MIRVarLocal, MIRAccessLocalVariable, MIRConstructorPrimary, MIRConstructorPrimaryCollectionCopies, MIRConstructorPrimaryCollectionSingletons, MIRConstructorPrimaryCollectionEmpty, MIRConstructorPrimaryCollectionMixed, MIRConstructorTuple, MIRConstructorRecord, MIRConstructorLambda, MIRCallNamespaceFunction, MIRCallStaticFunction, MIRProjectFromFields, MIRAccessFromField, MIRProjectFromProperties, MIRAccessFromProperty, MIRProjectFromIndecies, MIRAccessFromIndex, MIRProjectFromTypeTuple, MIRProjectFromTypeRecord, MIRProjectFromTypeConcept, MIRModifyWithIndecies, MIRModifyWithProperties, MIRModifyWithFields, MIRStructuredExtendTuple, MIRStructuredExtendRecord, MIRStructuredExtendObject, MIRInvokeKnownTarget, MIRInvokeVirtualTarget, MIRCallLambda, MIRPrefixOp, MIRBinOp, MIRBinEq, MIRBinCmp, MIRRegAssign, MIRTruthyConvert, MIRVarStore, MIRReturnAssign, MIRAssert, MIRCheck, MIRDebug, MIRPhi, MIRVarParameter, MIRVarCaptured, MIRIsTypeOfNone, MIRIsTypeOfSome, MIRIsTypeOf, MIRLogicStore } from "./mir_ops";
+import { MIRBody, MIRRegisterArgument, MIRBasicBlock, MIROpTag, MIRJumpNone, MIRJumpCond, MIROp, MIRValueOp, MIRTempRegister, MIRAccessCapturedVariable, MIRAccessArgVariable, MIRArgument, MIRVarLocal, MIRAccessLocalVariable, MIRConstructorPrimary, MIRConstructorPrimaryCollectionCopies, MIRConstructorPrimaryCollectionSingletons, MIRConstructorPrimaryCollectionEmpty, MIRConstructorPrimaryCollectionMixed, MIRConstructorTuple, MIRConstructorRecord, MIRConstructorLambda, MIRCallNamespaceFunction, MIRCallStaticFunction, MIRProjectFromFields, MIRAccessFromField, MIRProjectFromProperties, MIRAccessFromProperty, MIRProjectFromIndecies, MIRAccessFromIndex, MIRProjectFromTypeTuple, MIRProjectFromTypeRecord, MIRProjectFromTypeConcept, MIRModifyWithIndecies, MIRModifyWithProperties, MIRModifyWithFields, MIRStructuredExtendTuple, MIRStructuredExtendRecord, MIRStructuredExtendObject, MIRInvokeKnownTarget, MIRInvokeVirtualTarget, MIRCallLambda, MIRPrefixOp, MIRBinOp, MIRBinEq, MIRBinCmp, MIRRegAssign, MIRTruthyConvert, MIRVarStore, MIRReturnAssign, MIRDebug, MIRPhi, MIRVarParameter, MIRVarCaptured, MIRIsTypeOfNone, MIRIsTypeOfSome, MIRIsTypeOf, MIRLogicStore } from "./mir_ops";
 import { SourceInfo } from "../ast/parser";
 import { FlowLink, BlockLiveSet, computeBlockLinks, computeBlockLiveVars, topologicalOrder } from "./mir_info";
 
@@ -333,17 +333,7 @@ function assignSSA(op: MIROp, remap: Map<string, MIRRegisterArgument>, ctrs: Map
             ra.name = convertToSSA(ra.name, remap, ctrs) as MIRVarLocal;
             break;
         }
-        case MIROpTag.MIRAssert: {
-            const asrt = op as MIRAssert;
-            asrt.cond = processSSA_Use(asrt.cond, remap);
-            break;
-        }
-        case MIROpTag.MIRCheck: {
-            const chk = op as MIRCheck;
-            chk.cond = processSSA_Use(chk.cond, remap);
-            break;
-        }
-        case MIROpTag.MIRExhaustiveCheck: {
+        case MIROpTag.MIRAbort: {
             break;
         }
         case MIROpTag.MIRDebug: {
@@ -443,6 +433,7 @@ function convertBodyToSSA(body: MIRBody, args: string[], captured: string[]) {
             let remap = new Map<string, MIRRegisterArgument>();
             args.forEach((arg) => remap.set(arg, new MIRVarParameter(arg)));
             captured.forEach((capture) => remap.set(capture, new MIRVarCaptured(capture)));
+            remap.set("_ir_ret_", new MIRVarLocal("_ir_ret_"));
 
             for (let i = 0; i < block.ops.length; ++i) {
                 assignSSA(block.ops[i], remap, ctrs);

--- a/ref_impl/src/interpreter/interpreter.ts
+++ b/ref_impl/src/interpreter/interpreter.ts
@@ -6,7 +6,7 @@
 import { Value, TypedStringValue, EntityValueSimple, ValueOps, ListValue, HashSetValue, HashMapValue, TupleValue, RecordValue, LambdaValue } from "./value";
 import { Environment, PrePostError, raiseRuntimeError, FunctionScope, InvariantError, NotImplementedRuntimeError } from "./interpreter_environment";
 import { MIRAssembly, MIRTupleType, MIRTupleTypeEntry, MIRRecordTypeEntry, MIRRecordType, MIREntityType, MIREntityTypeDecl, MIRFieldDecl, MIROOTypeDecl, MIRType, MIRGlobalDecl, MIRConstDecl, MIRFunctionDecl, MIRStaticDecl, MIRConceptTypeDecl, MIRMethodDecl, MIRInvokeDecl, MIRFunctionType } from "../compiler/mir_assembly";
-import { MIRBody, MIROp, MIROpTag, MIRLoadConst, MIRArgument, MIRTempRegister, MIRRegisterArgument, MIRConstantTrue, MIRConstantString, MIRConstantInt, MIRConstantNone, MIRConstantFalse, MIRLoadConstTypedString, MIRAccessNamespaceConstant, MIRAccessConstField, MIRLoadFieldDefaultValue, MIRAccessCapturedVariable, MIRAccessArgVariable, MIRAccessLocalVariable, MIRConstructorPrimary, MIRConstructorPrimaryCollectionEmpty, MIRConstructorPrimaryCollectionSingletons, MIRConstructorPrimaryCollectionCopies, MIRConstructorPrimaryCollectionMixed, MIRConstructorTuple, MIRConstructorRecord, MIRConstructorLambda, MIRCallNamespaceFunction, MIRCallStaticFunction, MIRAccessFromIndex, MIRProjectFromIndecies, MIRAccessFromProperty, MIRAccessFromField, MIRProjectFromProperties, MIRProjectFromFields, MIRProjectFromTypeTuple, MIRProjectFromTypeRecord, MIRProjectFromTypeConcept, MIRModifyWithIndecies, MIRModifyWithProperties, MIRModifyWithFields, MIRStructuredExtendTuple, MIRStructuredExtendRecord, MIRStructuredExtendObject, MIRInvokeKnownTarget, MIRInvokeVirtualTarget, MIRCallLambda, MIRPrefixOp, MIRBinOp, MIRBinCmp, MIRBinEq, MIRRegAssign, MIRVarStore, MIRReturnAssign, MIRJump, MIRJumpCond, MIRJumpNone, MIRVarLifetimeStart, MIRVarLifetimeEnd, MIRCheck, MIRAssert, MIRTruthyConvert, MIRDebug, MIRPhi, MIRVarLocal, MIRIsTypeOfNone, MIRIsTypeOfSome, MIRIsTypeOf, MIRLogicStore } from "../compiler/mir_ops";
+import { MIRBody, MIROp, MIROpTag, MIRLoadConst, MIRArgument, MIRTempRegister, MIRRegisterArgument, MIRConstantTrue, MIRConstantString, MIRConstantInt, MIRConstantNone, MIRConstantFalse, MIRLoadConstTypedString, MIRAccessNamespaceConstant, MIRAccessConstField, MIRLoadFieldDefaultValue, MIRAccessCapturedVariable, MIRAccessArgVariable, MIRAccessLocalVariable, MIRConstructorPrimary, MIRConstructorPrimaryCollectionEmpty, MIRConstructorPrimaryCollectionSingletons, MIRConstructorPrimaryCollectionCopies, MIRConstructorPrimaryCollectionMixed, MIRConstructorTuple, MIRConstructorRecord, MIRConstructorLambda, MIRCallNamespaceFunction, MIRCallStaticFunction, MIRAccessFromIndex, MIRProjectFromIndecies, MIRAccessFromProperty, MIRAccessFromField, MIRProjectFromProperties, MIRProjectFromFields, MIRProjectFromTypeTuple, MIRProjectFromTypeRecord, MIRProjectFromTypeConcept, MIRModifyWithIndecies, MIRModifyWithProperties, MIRModifyWithFields, MIRStructuredExtendTuple, MIRStructuredExtendRecord, MIRStructuredExtendObject, MIRInvokeKnownTarget, MIRInvokeVirtualTarget, MIRCallLambda, MIRPrefixOp, MIRBinOp, MIRBinCmp, MIRBinEq, MIRRegAssign, MIRVarStore, MIRReturnAssign, MIRJump, MIRJumpCond, MIRJumpNone, MIRVarLifetimeStart, MIRVarLifetimeEnd, MIRTruthyConvert, MIRDebug, MIRPhi, MIRVarLocal, MIRIsTypeOfNone, MIRIsTypeOfSome, MIRIsTypeOf, MIRLogicStore, MIRAbort } from "../compiler/mir_ops";
 
 import * as assert from "assert";
 import { BuiltinCalls, BuiltinCallSig } from "./builtins";
@@ -730,22 +730,11 @@ class Interpreter {
                 fscope.assignVar(ra.name.nameID, this.getArgValue(fscope, ra.src));
                 break;
             }
-            case MIROpTag.MIRAssert: {
-                const asrt = op as MIRAssert;
-                if (this.m_doAssertCheck && !this.getArgValue(fscope, asrt.cond)) {
+            case MIROpTag.MIRAbort: {
+                const abrt = op as MIRAbort;
+                if (this.m_doAssertCheck || abrt.releaseEnable) {
                     raiseRuntimeError();
                 }
-                break;
-            }
-            case MIROpTag.MIRCheck: {
-                const chk = op as MIRCheck;
-                if (!this.getArgValue(fscope, chk.cond)) {
-                    raiseRuntimeError();
-                }
-                break;
-            }
-            case MIROpTag.MIRExhaustiveCheck: {
-                raiseRuntimeError();
                 break;
             }
             case MIROpTag.MIRDebug: {

--- a/ref_impl/src/test/basic_evaluation_test.ts
+++ b/ref_impl/src/test/basic_evaluation_test.ts
@@ -1543,6 +1543,24 @@ entrypoint function switchCaseEx_error(): Any {
     return switchCaseEx(@{});
 }
 
+entrypoint function abortOk(): Int {
+    if(1 < 2) {
+        return 1;
+    }
+    else {
+        abort;
+    }
+}
+
+entrypoint function abortFail(): Int {
+    if(1 == 2) {
+        return 1;
+    }
+    else {
+        abort;
+    }
+}
+
 entrypoint function assertOk(): Int {
     assert 1 < 2;
     return 1;
@@ -1672,8 +1690,10 @@ const statement_tests: TestInfo[] = [
 
     { name: "switchCaseEx_0", input: ["switchCaseEx_0"], expected: "0" },
     { name: "switchCaseEx_false", input: ["switchCaseEx_false"], expected: "false" },
-    { name: "switchCaseEx_error", input: ["switchCaseEx_error"], expected: "none", expectedError: true },
+    { name: "switchCaseEx_error", input: ["switchCaseEx_error"], expected: "[NO RESULT]", expectedError: true },
 
+    { name: "abortOk", input: ["abortOk"], expected: "1" },
+    { name: "abortFail", input: ["abortFail"], expected: "[NO RESULT]", expectedError: true },
     { name: "assertOk", input: ["assertOk"], expected: "1" },
     { name: "assertFail", input: ["assertFail"], expected: "[NO RESULT]", expectedError: true },
     { name: "checkOk", input: ["checkOk"], expected: "1" },

--- a/ref_impl/src/type_checker/type_environment.ts
+++ b/ref_impl/src/type_checker/type_environment.ts
@@ -172,6 +172,11 @@ class TypeEnvironment {
         return [nvals, svals];
     }
 
+    setAbort(): TypeEnvironment {
+        assert(this.hasNormalFlow());
+        return new TypeEnvironment(this.terms, this.args, this.captured, undefined, this.expressionResult, this.returnResult, this.yieldResult, this.frozenVars);
+    }
+
     setReturn(assembly: Assembly, rtype: ResolvedType): TypeEnvironment {
         assert(this.hasNormalFlow());
         const rrtype = this.returnResult !== undefined ? assembly.typeUnion([this.returnResult, rtype]) : rtype;


### PR DESCRIPTION
Changes:
Add abort operation to MIR
Simplify other failures by emitting test/jump/abort ops
