### PR TITLE
Fix for tuples with required params after optional

### DIFF
--- a/ref_impl/src/ast/assembly.ts
+++ b/ref_impl/src/ast/assembly.ts
@@ -453,6 +453,14 @@ class Assembly {
             return ResolvedType.createEmpty();
         }
 
+        let seenreq = false;
+        for (let i = entries.length - 1; i >= 0; --i) {
+            seenreq = seenreq || !entries[i].isOptional;
+            if (entries[i].isOptional && seenreq) {
+                return ResolvedType.createEmpty();
+            }
+        }
+
         return ResolvedType.createSingle(ResolvedTupleAtomType.create(t.isOpen, entries));
     }
 


### PR DESCRIPTION
Fixes a missing issue in type checker. The tuple type `[Int, ?:Bool, Int]` does not make much sense with respect to an omitted second parameter. To address this we check that required parameters come before any optional parameters.