### PR TITLE
Fix parameter mapping for records expanded with spread operator

### DIFF
--- a/ref_impl/src/test/regression_tests.ts
+++ b/ref_impl/src/test/regression_tests.ts
@@ -21,8 +21,22 @@ function allOdd(...args: List<Int>): Bool {
     return args->all(fn(x) => x % 2 == 1);
 }
 
-entrypoint function invokeLambdaInfer(): Bool {
+entrypoint function invokeLambdaInfer1(): Bool {
     return allOdd(1, 3, 4);
+}
+
+entrypoint function invokeLambdaInfer2(): Bool {
+    var t = List<Int>{1, 3, 5};
+    return allOdd(...t);
+}
+
+function np(p1: Int, p2: Int): {x: Int, y: Int} {
+    return {x=p1, y=p2};
+}
+
+entrypoint function invokeLambdaInfer3(): {x: Int, y: Int} {
+    var r = {p1=1, p2=2};
+    return np(...r);
 }
 
 function convert(x: Any) : Int {
@@ -77,7 +91,9 @@ entrypoint function argTypeFlow_entry(x?: Int): Int {
 
 const regression_tests: TestInfo[] = [
     { name: "stringTIncludes", input: ["stringTIncludes"], expected: "true" },
-    { name: "invokeLambdaInfer", input: ["invokeLambdaInfer"], expected: "false" },
+    { name: "invokeLambdaInfer1", input: ["invokeLambdaInfer1"], expected: "false" },
+    { name: "invokeLambdaInfer2", input: ["invokeLambdaInfer2"], expected: "true" },
+    { name: "invokeLambdaInfer3", input: ["invokeLambdaInfer3"], expected: "{ x=1, y=2 }" },
     { name: "vInvoke1", input: ["vInvoke1"], expected: "3" },
     { name: "vInvoke2", input: ["vInvoke2"], expected: "[NO RESULT]", expectedError: true },
     { name: "phimulti", input: ["phimulti"], expected: "true" },

--- a/ref_impl/src/type_checker/type_checker.ts
+++ b/ref_impl/src/type_checker/type_checker.ts
@@ -886,7 +886,7 @@ class TypeChecker {
                 this.raiseErrorIf(sinfo, !expandInfo[0], "Type cannot be expanded as part of call");
 
                 expandInfo[2].forEach((pname) => {
-                    const fidx = sig.params.findIndex((param) => param.name === arg.name);
+                    const fidx = sig.params.findIndex((param) => param.name === pname);
                     this.raiseErrorIf(sinfo, fidx === -1, `Call does not have parameter named "${arg.name}"`);
                     this.raiseErrorIf(sinfo, filledLocations[fidx] !== undefined, `Duplicate definition of parameter name "${arg.name}"`);
 


### PR DESCRIPTION
Fixes #192

Changes:
- Compare `param.name` with `pname` instead of `arg.name` when the parameter is expanded with spread operator.

<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
