### PR TITLE
Fix a typo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ function createAnimal(catchPhrase: String): Animal
     return Animal@{says=catchPhrase};
 }
 
-function createAnimal(catchPhrase: String): Animal
+function createAnimalPre(catchPhrase: String): Animal
     requires catchPhrase != "";
 {
     return Animal@{says=catchPhrase};


### PR DESCRIPTION
If I understand correctly, the `createAnimalPre` should be declared instead of declaring `createAnimal` twice.

