### PR TITLE
fix: use correct variable name in List sort

### DIFF
--- a/bosque-language-tools/bsqdrop/core/cpp/list.bsq
+++ b/bosque-language-tools/bsqdrop/core/cpp/list.bsq
@@ -465,7 +465,7 @@ entity List<T> provides Object, Expandoable<T>, PODType when T PODType, APIType 
     }
 
     recursive? method sort(cmp: recursive? fn(_: T, _: T) -> Bool): List<T> {
-        return List<T>::s_sort[recursive?](this, pf);
+        return List<T>::s_sort[recursive?](this, cmp);
     }
 
     recursive? method toMap<K where KeyType, V>(kf: recursive? fn(_: T) -> K, vf: recursive? fn(_: T) -> V, merge?: Bool): Map<K, V> {

--- a/bosque-language-tools/bsqdrop/core/symbolic/list.bsq
+++ b/bosque-language-tools/bsqdrop/core/symbolic/list.bsq
@@ -961,7 +961,7 @@ entity List<T> provides Object, Expandoable<T>, PODType when T PODType, APIType 
     }
 
     recursive? method sort(cmp: recursive? fn(_: T, _: T) -> Bool): List<T> {
-        return List<T>::s_sort[recursive](this, List<T>@{}, 0, pf);
+        return List<T>::s_sort[recursive](this, List<T>@{}, 0, cmp);
     }
 
     recursive? method toMap<K where KeyType, V>(kf: recursive? fn(_: T) -> K, vf: recursive? fn(_: T) -> V, merge?: Bool): Map<K, V> {

--- a/impl/src/core/cpp/list.bsq
+++ b/impl/src/core/cpp/list.bsq
@@ -465,7 +465,7 @@ entity List<T> provides Object, Expandoable<T>, PODType when T PODType, APIType 
     }
 
     recursive? method sort(cmp: recursive? fn(_: T, _: T) -> Bool): List<T> {
-        return List<T>::s_sort[recursive?](this, pf);
+        return List<T>::s_sort[recursive?](this, cmp);
     }
 
     recursive? method toMap<K where KeyType, V>(kf: recursive? fn(_: T) -> K, vf: recursive? fn(_: T) -> V, merge?: Bool): Map<K, V> {

--- a/impl/src/core/symbolic/list.bsq
+++ b/impl/src/core/symbolic/list.bsq
@@ -961,7 +961,7 @@ entity List<T> provides Object, Expandoable<T>, PODType when T PODType, APIType 
     }
 
     recursive? method sort(cmp: recursive? fn(_: T, _: T) -> Bool): List<T> {
-        return List<T>::s_sort[recursive](this, List<T>@{}, 0, pf);
+        return List<T>::s_sort[recursive](this, List<T>@{}, 0, cmp);
     }
 
     recursive? method toMap<K where KeyType, V>(kf: recursive? fn(_: T) -> K, vf: recursive? fn(_: T) -> V, merge?: Bool): Map<K, V> {


### PR DESCRIPTION
Fixes https://github.com/microsoft/BosqueLanguage/issues/247

Changes:

This PR fixes a small bug in List's **sort** method by replacing the variable name `pf` with `cmp`.