### PR TITLE
[compiler] fix fallthrough bug in list_max

### DIFF
--- a/impl/src/tooling/aot/cppbody_emitter.ts
+++ b/impl/src/tooling/aot/cppbody_emitter.ts
@@ -1878,6 +1878,7 @@ class CPPBodyEmitter {
                 const ctype = this.getListContentsInfoForListOp(idecl);
                 const lambda = this.typegen.getFunctorsForType(ctype).less;
                 bodystr = `auto $$return = ${this.createListOpsFor(ltype, ctype)}::list_max(${params[0]}, ${lambda}{});`
+                break;
             }
             case "list_sum": {
                 assert(false, "Need to implement");


### PR DESCRIPTION
Fixes https://github.com/microsoft/BosqueLanguage/issues/256

Changes:
Compilation of programs that use List's *max* method fails with an assertion error ("not implemented"). This PR fixes it by adding the missing **break** statement.
