### PR TITLE
[compiler] fix map.has(key) bug

### DIFF
--- a/impl/src/core/cpp/map.bsq
+++ b/impl/src/core/cpp/map.bsq
@@ -66,7 +66,7 @@ entity Map<K where KeyType, V> provides Object, Expandoable<MapEntry<K, V>>, POD
     }
 
     method has(key: K): Bool {
-        return Map<K, V>::s_has_key(this, k);
+        return Map<K, V>::s_has_key(this, key);
     }
 
     method hasAll(...kl: List<K>): Bool {

--- a/impl/src/core/symbolic/map.bsq
+++ b/impl/src/core/symbolic/map.bsq
@@ -245,7 +245,7 @@ entity Map<K where KeyType, V> provides Object, Expandoable<MapEntry<K, V>>, POD
     }
 
     method has(key: K): Bool {
-        return Map<K, V>::s_has_key(this, k);
+        return Map<K, V>::s_has_key(this, key);
     }
 
     method hasAll(...kl: List<K>): Bool {


### PR DESCRIPTION
Fixes https://github.com/microsoft/BosqueLanguage/issues/261

Changes:
Change variable name to "key".
