### PR TITLE
[compiler] fix map.get(key) bug

### DIFF
--- a/impl/src/core/cpp/map.bsq
+++ b/impl/src/core/cpp/map.bsq
@@ -83,9 +83,9 @@ entity Map<K where KeyType, V> provides Object, Expandoable<MapEntry<K, V>>, POD
     }
 
     method get(key: K): V 
-        requires release Map<K, V>::s_has_key(this, k);
+        requires release Map<K, V>::s_has_key(this, key);
     {
-        return Map<K, V>::s_at_val(this, k);
+        return Map<K, V>::s_at_val(this, key);
     }
 
     method tryGet(k: K): V? {

--- a/impl/src/core/symbolic/map.bsq
+++ b/impl/src/core/symbolic/map.bsq
@@ -262,9 +262,9 @@ entity Map<K where KeyType, V> provides Object, Expandoable<MapEntry<K, V>>, POD
     }
 
     method get(key: K): V 
-        requires release Map<K, V>::s_has_key(this, k);
+        requires release Map<K, V>::s_has_key(this, key);
     {
-        return Map<K, V>::s_at_val(this, k);
+        return Map<K, V>::s_at_val(this, key);
     }
 
     method tryGet(k: K): V? {


### PR DESCRIPTION
Fixes https://github.com/microsoft/BosqueLanguage/issues/263

Changes:

Changes the forwarded variable name to "key".