### PR TITLE
Fix for identity basics

### DIFF
--- a/impl/src/ast/parser.ts
+++ b/impl/src/ast/parser.ts
@@ -3133,9 +3133,13 @@ class Parser {
             }
 
             const consparams = components.map((cmp) => new FunctionParameter(cmp.cname, cmp.ctype, false, false));
-            const body = new BodyImplementation(`${this.m_penv.getCurrentFile()}::${sinfo.pos}`, this.m_penv.getCurrentFile(), "idkey_from");
+            const body = new BodyImplementation(`${this.m_penv.getCurrentFile()}::${sinfo.pos}`, this.m_penv.getCurrentFile(), "idkey_from_composite");
             const createdecl = new InvokeDecl(sinfo, this.m_penv.getCurrentFile(), [], "no", [], [], undefined, consparams, undefined, undefined, simpleITypeResult, [], [], false, new Set<string>(), body);
             const create = new StaticFunctionDecl(sinfo, this.m_penv.getCurrentFile(), [], "create", createdecl);
+
+            const gkbody = new BodyImplementation(`${this.m_penv.getCurrentFile()}::${sinfo.pos}`, this.m_penv.getCurrentFile(), "idkey_getkey_composite");
+            const gkdecl = new InvokeDecl(sinfo, this.m_penv.getCurrentFile(), [], "no", [], [], undefined, [], undefined, undefined, idval, [], [], false, new Set<string>(), gkbody);
+            const gk = new StaticFunctionDecl(sinfo, this.m_penv.getCurrentFile(), [], "key", gkdecl);
 
             let provides = [[new NominalTypeSignature("NSCore", "IdKey"), undefined]] as [TypeSignature, TypeConditionRestriction | undefined][];
 
@@ -3144,29 +3148,33 @@ class Parser {
                     
             const invariants: InvariantDecl[] = [];
             const staticMembers = new Map<string, StaticMemberDecl>();
-            const staticFunctions = new Map<string, StaticFunctionDecl>().set("create", create);
+            const staticFunctions = new Map<string, StaticFunctionDecl>().set("create", create).set("key", gk);
             const memberFields = new Map<string, MemberFieldDecl>();
             const memberMethods = new Map<string, MemberMethodDecl>();
 
-            currentDecl.objects.set(iname, new EntityTypeDecl(sinfo, this.m_penv.getCurrentFile(), pragmas, attributes, currentDecl.ns, iname, [], provides, invariants, staticMembers, staticFunctions, memberFields, memberMethods));
+            currentDecl.objects.set(iname, new EntityTypeDecl(sinfo, this.m_penv.getCurrentFile(), pragmas, ["identifier_composite", ...attributes], currentDecl.ns, iname, [], provides, invariants, staticMembers, staticFunctions, memberFields, memberMethods));
             this.m_penv.assembly.addObjectDecl(currentDecl.ns + "::" + iname, currentDecl.objects.get(iname) as EntityTypeDecl);
         }
         else {
             const param = new FunctionParameter("value", idval, false, false);
-            const body = new BodyImplementation(`${this.m_penv.getCurrentFile()}::${sinfo.pos}`, this.m_penv.getCurrentFile(), "idkey_from");
+            const body = new BodyImplementation(`${this.m_penv.getCurrentFile()}::${sinfo.pos}`, this.m_penv.getCurrentFile(), "idkey_from_simple");
             const createdecl = new InvokeDecl(sinfo, this.m_penv.getCurrentFile(), [], "no", [], [], undefined, [param], undefined, undefined, simpleITypeResult, [], [], false, new Set<string>(), body);
             const create = new StaticFunctionDecl(sinfo, this.m_penv.getCurrentFile(), [], "create", createdecl);
+
+            const gkbody = new BodyImplementation(`${this.m_penv.getCurrentFile()}::${sinfo.pos}`, this.m_penv.getCurrentFile(), "idkey_getkey_simple");
+            const gkdecl = new InvokeDecl(sinfo, this.m_penv.getCurrentFile(), [], "no", [], [], undefined, [], undefined, undefined, idval, [], [], false, new Set<string>(), gkbody);
+            const gk = new StaticFunctionDecl(sinfo, this.m_penv.getCurrentFile(), [], "key", gkdecl);
 
             let provides = [[new NominalTypeSignature("NSCore", "IdKey"), undefined]] as [TypeSignature, TypeConditionRestriction | undefined][];
             provides.push([new NominalTypeSignature("NSCore", "APIType"), new TypeConditionRestriction([new TemplateTypeRestriction(idval, new NominalTypeSignature("NSCore", "APIType"))])]);
 
             const invariants: InvariantDecl[] = [];
             const staticMembers = new Map<string, StaticMemberDecl>();
-            const staticFunctions = new Map<string, StaticFunctionDecl>().set("create", create);
+            const staticFunctions = new Map<string, StaticFunctionDecl>().set("create", create).set("key", gk);
             const memberFields = new Map<string, MemberFieldDecl>();
             const memberMethods = new Map<string, MemberMethodDecl>();
 
-            currentDecl.objects.set(iname, new EntityTypeDecl(sinfo, this.m_penv.getCurrentFile(), pragmas, attributes, currentDecl.ns, iname, [], provides, invariants, staticMembers, staticFunctions, memberFields, memberMethods));
+            currentDecl.objects.set(iname, new EntityTypeDecl(sinfo, this.m_penv.getCurrentFile(), pragmas, ["identifier_simple", ...attributes], currentDecl.ns, iname, [], provides, invariants, staticMembers, staticFunctions, memberFields, memberMethods));
             this.m_penv.assembly.addObjectDecl(currentDecl.ns + "::" + iname, currentDecl.objects.get(iname) as EntityTypeDecl);
         }
     }

--- a/impl/src/tooling/aot/cppbody_emitter.ts
+++ b/impl/src/tooling/aot/cppbody_emitter.ts
@@ -1767,6 +1767,16 @@ class CPPBodyEmitter {
                 bodystr = `auto $$return = BSQEnum{ (uint32_t)BSQ_GET_VALUE_TAGGED_INT(${params[0]}), MIRNominalTypeEnum::${this.typegen.mangleStringForCpp(this.currentRType.trkey)} };`;
                 break;
             }
+            case "idkey_from_simple": {
+                const kv = this.typegen.coerce(params[0], this.typegen.getMIRType(idecl.params[0].type), this.typegen.keyType);
+                bodystr = `auto $$return = BSQIdKeySimple{ ${kv}, MIRNominalTypeEnum::${this.typegen.mangleStringForCpp(this.currentRType.trkey)} };`;
+                break;
+            }
+            case "idkey_from_composite": {
+                const kvs = params.map((p, i) => this.typegen.coerce(p, this.typegen.getMIRType(idecl.params[i].type), this.typegen.keyType));
+                bodystr = `auto $$return = BSQ_NEW_NO_RC(BSQIdKeyCompound, { ${kvs.join(", ")}, MIRNominalTypeEnum::${this.typegen.mangleStringForCpp(this.currentRType.trkey)});`;
+                break;
+            }
             case "string_count": {
                 bodystr = `auto $$return = ${params[0]}->sdata.size();`;
                 break;
@@ -2017,6 +2027,10 @@ class CPPBodyEmitter {
                 const [utype, ucontents, utag] = this.getListResultTypeFor(idecl);
                 const lambda = this.createLambdaFor(idecl.pcodes.get("f") as MIRPCode);
                 bodystr = `auto $$return = ${this.createListOpsFor(ltype, ctype)}::list_mapindex<${utype}, ${ucontents}, ${utag}>(${params[0]}, ${lambda});`
+                break;
+            }
+            case "set_size": {
+                bodystr = `auto $$return = ${params[0]}->entries.size();`;
                 break;
             }
             case "set_has_key": {

--- a/impl/src/tooling/aot/cpptype_emitter.ts
+++ b/impl/src/tooling/aot/cpptype_emitter.ts
@@ -282,12 +282,12 @@ class CPPTypeEmitter {
             return new RefRepr(true, "BSQCryptoHash", "BSQCryptoHash*", "MIRNominalTypeEnum_Category_CryptoHash");
         }
         else if (this.typecheckEntityAndProvidesName_Option(tt, this.enumtype)) {
-            return new StructRepr(true, "BSQEnum", "Boxed_BSQEnum", `MIRNominalTypeEnum_${this.mangleStringForCpp(tt.trkey)}`, "MIRNominalTypeEnum_Category_Enum");
+            return new StructRepr(true, "BSQEnum", "Boxed_BSQEnum", `MIRNominalTypeEnum::${this.mangleStringForCpp(tt.trkey)}`, "MIRNominalTypeEnum_Category_Enum");
         }
         else if (this.typecheckEntityAndProvidesName_Option(tt, this.idkeytype)) {
             const iddecl = this.assembly.entityDecls.get(tt.trkey) as MIREntityTypeDecl;
-            if(iddecl.fields.length === 1) {
-                return new StructRepr(true, "BSQIdKeySimple", "Boxed_BSQIdKeySimple", `MIRNominalTypeEnum_${this.mangleStringForCpp(tt.trkey)}`, "MIRNominalTypeEnum_Category_IdKeySimple");
+            if(iddecl.attributes.includes("identifier_simple")) {
+                return new StructRepr(true, "BSQIdKeySimple", "Boxed_BSQIdKeySimple", `MIRNominalTypeEnum::${this.mangleStringForCpp(tt.trkey)}`, "MIRNominalTypeEnum_Category_IdKeySimple");
             }
             else {
                 return new RefRepr(true, "BSQIdKeyCompound", "BSQIdKeyCompound*", "MIRNominalTypeEnum_Category_IdKeyCompound");
@@ -431,12 +431,17 @@ class CPPTypeEmitter {
             else if (trfrom.base === "int64_t") {
                 cc = `BSQ_ENCODE_VALUE_TAGGED_INT(${exp})`;
             }
+            else if (trfrom.base === "BSQEnum" || trfrom.base === "BSQIdKeySimple" || trfrom.base === "BSQIdKeyCompound") {
+                const scope = this.mangleStringForCpp("$scope$");
+                const ops = this.getFunctorsForType(from);
+                cc = `BSQ_NEW_ADD_SCOPE(${scope}, ${trfrom.boxed}, ${trfrom.nominaltype}, ${ops.inc}{}(${exp}))`;
+            }
             else {
                 const scope = this.mangleStringForCpp("$scope$");
                 const ops = this.getFunctorsForType(from);
                 cc = `BSQ_NEW_ADD_SCOPE(${scope}, ${trfrom.boxed}, ${ops.inc}{}(${exp}))`;
             }
-
+                
             if (trinto instanceof KeyValueRepr) {
                 return `((KeyValue)${cc})`;
             }

--- a/impl/src/tooling/bmc/runtime/smtruntime.smt2
+++ b/impl/src/tooling/bmc/runtime/smtruntime.smt2
@@ -21,7 +21,8 @@
       (bsq_logicaltime 0)
       (bsq_cryptohash 0)
       (bsq_enum 0)
-      (bsq_idkey 0)
+      (bsq_idkeysimple 0)
+      (bsq_idkeycompound 0)
       (BKeyValue 0)
     ) (
     ( (bsq_safestring@cons (bsq_safestring_type Int) (bsq_safestring_value String)) )
@@ -30,7 +31,8 @@
     ( (bsq_logicaltime@cons (bsq_logicaltime_value Int)) )
     ( (bsq_cryptohash@cons (bsq_cryptohash_value String)) )
     ( (bsq_enum@cons (bsq_enum_type Int) (bsq_enum_value Int)) )
-    ( (bsq_idkey@cons (bsq_idkey_type Int) (bsq_idkey_value (Array Int BKeyValue))) )
+    ( (bsq_idkeysimple@cons (bsq_idkeysimple_type Int) (bsq_idkeysimple_value BKeyValue)) )
+    ( (bsq_idkeycompound@cons (bsq_idkeycompound_type Int) (bsq_idkeycompound_value (Array Int BKeyValue))) )
     (
       (bsqkey_none) 
       (bsqkey_bool (bsqkey_bool_value Bool))
@@ -43,7 +45,8 @@
       (bsqkey_logicaltime (bsqkey_logicaltime_value bsq_logicaltime))
       (bsqkey_cryptohash (bsqkey_cryptohash_value bsq_cryptohash))
       (bsqkey_enum (bsqkey_enum_value bsq_enum))
-      (bsqkey_idkey (bsqkey_idkey_value bsq_idkey))
+      (bsqkey_idkeysimple (bsqkey_idkeysimple_value bsq_idkeysimple))
+      (bsqkey_idkeycompound (bsqkey_idkeycompound_value bsq_idkeycompound))
     )
 ))
 
@@ -120,7 +123,9 @@
                   (ite (is-bsqkey_logicaltime keyv) MIRNominalTypeEnum_LogicalTime
                     (ite (is-bsqkey_cryptohash keyv) MIRNominalTypeEnum_CryptoHash
                       (ite (is-bsqkey_enum keyv) (bsq_enum_type (bsqkey_enum_value keyv))
-                        (bsq_idkey_type (bsqkey_idkey_value keyv))
+                        (ite (is-bsqkey_idkeysimple keyv) (bsq_idkeysimple_type (bsqkey_idkeysimple_value keyv))
+                          (bsq_idkeycompound_type (bsqkey_idkeycompound_value keyv))
+                        )
                       )
                     )
                   )
@@ -185,7 +190,14 @@
   )
 )
 
-(define-fun bsqkeyless_identity ((idtype Int) (k1 bsq_idkey) (k2 bsq_idkey)) Bool
+(define-fun bsqkeyless_identitysimple ((idtype Int) (k1 bsq_idkeysimple) (k2 bsq_idkeysimple)) Bool
+;;
+;;TODO -- need to gas bound and generate this (and bsqkeyless programatically)
+;;
+false
+)
+
+(define-fun bsqkeyless_identitycompound ((idtype Int) (k1 bsq_idkeycompound) (k2 bsq_idkeycompound)) Bool
 ;;
 ;;TODO -- need to gas bound and generate this (and bsqkeyless programatically)
 ;;
@@ -196,9 +208,12 @@ false
   (let ((k1t (bsqkey_get_nominal_type k1)) (k2t (bsqkey_get_nominal_type k2)))
     (ite (not (= k1t k2t))
       (< k1t k2t)
-      (ite (and (is-bsqkey_idkey k1) (is-bsqkey_idkey k2))
-        (bsqkeyless_identity k1t (bsqkey_idkey_value k1) (bsqkey_idkey_value k2))
-        (bsqkeyless_basetypes k1 k2)
+      (ite (and (is-bsqkey_idkeycompound k1) (is-bsqkey_idkeycompound k2))
+        (bsqkeyless_identitycompound k1t (bsqkey_idkeycompound_value k1) (bsqkey_idkeycompound_value k2))
+        (ite (and (is-bsqkey_idkeysimple k1) (is-bsqkey_idkeysimple k2))
+          (bsqkeyless_identitysimple k1t (bsqkey_idkeysimple_value k1) (bsqkey_idkeysimple_value k2))
+          (bsqkeyless_basetypes k1 k2)
+        )
       )
     )
   )

--- a/impl/src/tooling/bmc/smttype_emitter.ts
+++ b/impl/src/tooling/bmc/smttype_emitter.ts
@@ -257,7 +257,13 @@ class SMTTypeEmitter {
             return "bsq_enum";
         }
         else if (this.typecheckEntityAndProvidesName(tt, this.idkeytype)) {
-            return "bsq_idkey";
+            const iddecl = this.assembly.entityDecls.get(tt.trkey) as MIREntityTypeDecl;
+            if (iddecl.attributes.includes("identifier_simple")) {
+                return "bsq_idkeysimple";
+            }
+            else {
+                return "bsq_idkeycompound";
+            }
         }
         else {
             if(this.typecheckAllKeys(tt)) {
@@ -333,7 +339,13 @@ class SMTTypeEmitter {
                 ctoval = `(bsqkey_enum ${exp.emit()})`;
             }
             else {
-                ctoval = `(bsqkey_idkey ${exp.emit()})`;
+                const iddecl = this.assembly.entityDecls.get(from.trkey) as MIREntityTypeDecl;
+                if (iddecl.attributes.includes("identifier_simple")) {
+                    ctoval = `(bsqkey_idkeysimple ${exp.emit()})`;
+                }
+                else {
+                    ctoval = `(bsqkey_idkeycompound ${exp.emit()})`;
+                }
             }
 
             return (intotype === "BKeyValue") ? new SMTValue(ctoval) : new SMTValue(`(bsqterm_key ${ctoval})`);
@@ -372,7 +384,13 @@ class SMTTypeEmitter {
             return new SMTValue(`(bsqkey_enum_value ${exp.emit()})`);
         }
         else {
-            return new SMTValue(`(bsqkey_idkey_value ${exp.emit()})`);
+            const iddecl = this.assembly.entityDecls.get(into.trkey) as MIREntityTypeDecl;
+            if (iddecl.attributes.includes("identifier_simple")) {
+                return new SMTValue(`(bsqkey_idkeysimple_value ${exp.emit()})`);
+            }
+            else {
+                return new SMTValue(`(bsqkey_idkeycompound_value ${exp.emit()})`);
+            }
         }
     }
 
@@ -444,7 +462,13 @@ class SMTTypeEmitter {
                 return new SMTValue(`(bsq_enum_value ${cfrom})`);
             }
             else {
-                return new SMTValue(`(bsq_idkey_value ${cfrom})`);
+                const iddecl = this.assembly.entityDecls.get(into.trkey) as MIREntityTypeDecl;
+                if (iddecl.attributes.includes("identifier_simple")) {
+                    return new SMTValue(`(bsq_idkeysimple_value ${cfrom})`);
+                }
+                else {
+                    return new SMTValue(`(bsq_idkeycompound_value ${cfrom})`);
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #249 

Changes:
Add partial support for identifiers.

Todo includes:
SymTest less operator generation for keys
Typechecker report error if explicit constructor is used instead of create.
