### PR TITLE
[compiler] fix creation of BSQIdKeyCompound in emitter & runtime

### DIFF
--- a/impl/src/tooling/aot/cppbody_emitter.ts
+++ b/impl/src/tooling/aot/cppbody_emitter.ts
@@ -1774,7 +1774,7 @@ class CPPBodyEmitter {
             }
             case "idkey_from_composite": {
                 const kvs = params.map((p, i) => this.typegen.coerce(p, this.typegen.getMIRType(idecl.params[i].type), this.typegen.keyType));
-                bodystr = `auto $$return = BSQ_NEW_NO_RC(BSQIdKeyCompound, { ${kvs.join(", ")}, MIRNominalTypeEnum::${this.typegen.mangleStringForCpp(this.currentRType.trkey)});`;
+                bodystr = `auto $$return = BSQ_NEW_NO_RC(BSQIdKeyCompound, {${kvs.join(", ")}}, MIRNominalTypeEnum::${this.typegen.mangleStringForCpp(this.currentRType.trkey)});`;
                 break;
             }
             case "string_count": {

--- a/impl/src/tooling/aot/runtime/bsqkeyvalues.h
+++ b/impl/src/tooling/aot/runtime/bsqkeyvalues.h
@@ -625,4 +625,14 @@ struct DisplayFunctor_BSQIdKeyCompound
         return rvals;
     }
 };
+struct RCReturnFunctor_BSQIdKeyCompound
+{
+    inline void operator()(BSQIdKeyCompound* idk, BSQRefScope& scope) const
+    {
+        for(size_t i = 0; i < idk->keys.size(); ++i)
+        {
+            scope.processReturnChecked(idk->keys[i]);
+        }
+    }
+};
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/BosqueLanguage/issues/273

Changes:
This PR fixes two problems regarding compound identifiers:

* missing closing } in **cppbody_emitter.ts**
* missing `struct RCReturnFunctor_BSQIdKeyCompound`definition in **bsqkeyvalues.h**.
