### PR TITLE
Compound identifiers fix and tweak design

### DIFF
--- a/impl/src/ast/parser.ts
+++ b/impl/src/ast/parser.ts
@@ -320,18 +320,10 @@ class Lexer {
             return false;
         }
 
-        if (m.groups) {
-            const groups = m.groups;
-            if (groups.multiline !== undefined) {
-                for (const char of groups.multiline) {
-                    if (char === "\n") {
-                        this.m_cline++;
-                    }
-                }
-            }
-            if (groups.multilineEndChar !== undefined && groups.multilineEndChar !== "/")
-            {
-                this.recordLexToken(this.m_cpos, TokenStrings.Error);
+        for (let i = 0; i < m[0].length; ++i) {
+            if (m[0][i] === "\n") {
+                this.m_cline++;
+                this.m_linestart = this.m_cpos + i + 1;
             }
         }
 
@@ -3132,9 +3124,9 @@ class Parser {
                 components = idval.entries.map((re, i) => { return {cname: re[0], ctype: re[1]} });
             }
 
-            const consparams = components.map((cmp) => new FunctionParameter(cmp.cname, cmp.ctype, false, false));
+            const param =  new FunctionParameter("value", idval, false, false);
             const body = new BodyImplementation(`${this.m_penv.getCurrentFile()}::${sinfo.pos}`, this.m_penv.getCurrentFile(), "idkey_from_composite");
-            const createdecl = new InvokeDecl(sinfo, this.m_penv.getCurrentFile(), [], "no", [], [], undefined, consparams, undefined, undefined, simpleITypeResult, [], [], false, new Set<string>(), body);
+            const createdecl = new InvokeDecl(sinfo, this.m_penv.getCurrentFile(), [], "no", [], [], undefined, [param], undefined, undefined, simpleITypeResult, [], [], false, new Set<string>(), body);
             const create = new StaticFunctionDecl(sinfo, this.m_penv.getCurrentFile(), [], "create", createdecl);
 
             const gkbody = new BodyImplementation(`${this.m_penv.getCurrentFile()}::${sinfo.pos}`, this.m_penv.getCurrentFile(), "idkey_getkey_composite");

--- a/impl/src/tooling/aot/cppbody_emitter.ts
+++ b/impl/src/tooling/aot/cppbody_emitter.ts
@@ -1773,8 +1773,22 @@ class CPPBodyEmitter {
                 break;
             }
             case "idkey_from_composite": {
-                const kvs = params.map((p, i) => this.typegen.coerce(p, this.typegen.getMIRType(idecl.params[i].type), this.typegen.keyType));
-                bodystr = `auto $$return = BSQ_NEW_NO_RC(BSQIdKeyCompound, { ${kvs.join(", ")}, MIRNominalTypeEnum::${this.typegen.mangleStringForCpp(this.currentRType.trkey)});`;
+                const ptype = this.typegen.getMIRType(idecl.params[0].type);
+                let kvs: string[] = [];
+                //
+                //TODO: we chat and use the fact that tuples/records are also uniform representation to skip any coerce ops
+                //
+                if(ptype.options[0] instanceof MIRTupleType) {
+                    kvs = (ptype.options[0] as MIRTupleType).entries.map((e, i) => {
+                        return `${params[0]}.atFixed<${i}>()`;
+                    });
+                }
+                else {
+                    kvs = (ptype.options[0] as MIRRecordType).entries.map((e) => {
+                        return `${params[0]}.atFixed<MIRPropertyEnum::${e.name}>()`;
+                    });
+                }
+                bodystr = `auto $$return = BSQIdKeyCompound{ { ${kvs.join(", ")} }, MIRNominalTypeEnum::${this.typegen.mangleStringForCpp(this.currentRType.trkey)} };`;
                 break;
             }
             case "string_count": {

--- a/impl/src/tooling/aot/cpptype_emitter.ts
+++ b/impl/src/tooling/aot/cpptype_emitter.ts
@@ -290,7 +290,7 @@ class CPPTypeEmitter {
                 return new StructRepr(true, "BSQIdKeySimple", "Boxed_BSQIdKeySimple", `MIRNominalTypeEnum::${this.mangleStringForCpp(tt.trkey)}`, "MIRNominalTypeEnum_Category_IdKeySimple");
             }
             else {
-                return new RefRepr(true, "BSQIdKeyCompound", "BSQIdKeyCompound*", "MIRNominalTypeEnum_Category_IdKeyCompound");
+                return new StructRepr(true, "BSQIdKeyCompound", "Boxed_BSQIdKeyCompound", `MIRNominalTypeEnum::${this.mangleStringForCpp(tt.trkey)}`, "MIRNominalTypeEnum_Category_IdKeyCompound");
             }
         }
         else {

--- a/impl/src/tooling/aot/runtime/bsqvalue.cpp
+++ b/impl/src/tooling/aot/runtime/bsqvalue.cpp
@@ -104,7 +104,7 @@ bool bsqKeyValueEqual(KeyValue v1, KeyValue v2)
             case MIRNominalTypeEnum_Category_IdKeySimple:
                 return BSQIdKeySimple::keyEqual(dynamic_cast<Boxed_BSQIdKeySimple*>(ptr1)->bval, dynamic_cast<Boxed_BSQIdKeySimple*>(ptr2)->bval);
             default:
-                return BSQIdKeyCompound::keyEqual(dynamic_cast<BSQIdKeyCompound*>(ptr1), dynamic_cast<BSQIdKeyCompound*>(ptr2));
+                return BSQIdKeyCompound::keyEqual(dynamic_cast<Boxed_BSQIdKeyCompound*>(ptr1)->bval, dynamic_cast<Boxed_BSQIdKeyCompound*>(ptr2)->bval);
         }
     }
 }
@@ -156,7 +156,7 @@ bool bsqKeyValueLess(KeyValue v1, KeyValue v2)
             case MIRNominalTypeEnum_Category_IdKeySimple:
                 return BSQIdKeySimple::keyLess(dynamic_cast<Boxed_BSQIdKeySimple*>(ptr1)->bval, dynamic_cast<Boxed_BSQIdKeySimple*>(ptr2)->bval);
             default:
-                return BSQIdKeyCompound::keyLess(dynamic_cast<BSQIdKeyCompound*>(ptr1), dynamic_cast<BSQIdKeyCompound*>(ptr2));
+                return BSQIdKeyCompound::keyLess(dynamic_cast<Boxed_BSQIdKeyCompound*>(ptr1)->bval, dynamic_cast<Boxed_BSQIdKeyCompound*>(ptr2)->bval);
         }
     }
 }
@@ -223,7 +223,7 @@ std::string diagnostic_format(Value v)
             case MIRNominalTypeEnum_Category_IdKeySimple:
                 return DisplayFunctor_BSQIdKeySimple{}(dynamic_cast<Boxed_BSQIdKeySimple*>(vv)->bval);
             case MIRNominalTypeEnum_Category_IdKeyCompound:
-                return DisplayFunctor_BSQIdKeyCompound{}(dynamic_cast<BSQIdKeyCompound*>(vv));
+                return DisplayFunctor_BSQIdKeyCompound{}(dynamic_cast<Boxed_BSQIdKeyCompound*>(vv)->bval);
             case MIRNominalTypeEnum_Category_Float64:
                 return DisplayFunctor_double{}(dynamic_cast<Boxed_double*>(vv)->bval);
             case MIRNominalTypeEnum_Category_ByteBuffer:

--- a/impl/src/tooling/bmc/smtbody_emitter.ts
+++ b/impl/src/tooling/bmc/smtbody_emitter.ts
@@ -1817,8 +1817,23 @@ class SMTBodyEmitter {
                 break;
             }
             case "idkey_from_composite": {
-                const kvs = params.map((p, i) => this.typegen.coerce(new SMTValue(p), this.typegen.getMIRType(idecl.params[i].type), this.typegen.keyType).emit());
-                bodyres = new SMTValue(`(bsq_idkeycompound@cons MIRNominalTypeEnum_${this.typegen.mangleStringForSMT(enclkey)} ${kvs.join(" ")})`);
+                const ptype = this.typegen.getMIRType(idecl.params[0].type);
+                let kvs: string = "bsqidkey_array_empty";
+                if(ptype.options[0] instanceof MIRTupleType) {
+                    const tentries = (ptype.options[0] as MIRTupleType).entries;
+                    for (let i = 0; i < tentries.length; ++i) {
+                        const select = this.typegen.coerce(new SMTValue(`(select (bsq_tuple_entries ${params[0]}) ${i})`), this.typegen.anyType, this.typegen.keyType);
+                        kvs = `(store ${kvs} ${i} ${select.emit()})`;
+                    }
+                }
+                else {
+                    const rentries = (ptype.options[0] as MIRRecordType).entries;
+                    for (let i = 0; i < rentries.length; ++i) {
+                        const select = this.typegen.coerce(new SMTValue(`(select (bsq_record_entries ${params[0]}) "${rentries[i].name}")`), this.typegen.anyType, this.typegen.keyType);
+                        kvs = `(store ${kvs} ${i} ${select.emit()})`;
+                    }
+                }
+                bodyres = new SMTValue(`(bsq_idkeycompound@cons MIRNominalTypeEnum_${this.typegen.mangleStringForSMT(enclkey)} ${kvs})`);
                 break;
             }
             case "string_count": {


### PR DESCRIPTION
Fixes #275 #273

Changes:
Make Compound Key a value type (everywhere)
Fix bug in less code
Change constructor (create) to take the tuple/record instead of individual values
