### PR TITLE
Revert CompoundKey create signature

### DIFF
--- a/impl/src/ast/parser.ts
+++ b/impl/src/ast/parser.ts
@@ -3104,6 +3104,12 @@ class Parser {
         const simpleITypeResult = itype;
 
         this.ensureAndConsumeToken("=");
+
+        //
+        //TODO: Parse this explicitly to preserve the order of "properties" and enforce no optional
+        //      This is needed to keep the order of params in the constructor stable (and developer friendly)
+        //      Will be a breaking change though!
+        //
         const idval = this.parseTypeSignature();
         this.ensureAndConsumeToken(";");
 
@@ -3124,9 +3130,9 @@ class Parser {
                 components = idval.entries.map((re, i) => { return {cname: re[0], ctype: re[1]} });
             }
 
-            const param =  new FunctionParameter("value", idval, false, false);
+            const consparams = components.map((cmp) => new FunctionParameter(cmp.cname, cmp.ctype, false, false));
             const body = new BodyImplementation(`${this.m_penv.getCurrentFile()}::${sinfo.pos}`, this.m_penv.getCurrentFile(), "idkey_from_composite");
-            const createdecl = new InvokeDecl(sinfo, this.m_penv.getCurrentFile(), [], "no", [], [], undefined, [param], undefined, undefined, simpleITypeResult, [], [], false, new Set<string>(), body);
+            const createdecl = new InvokeDecl(sinfo, this.m_penv.getCurrentFile(), [], "no", [], [], undefined, consparams, undefined, undefined, simpleITypeResult, [], [], false, new Set<string>(), body);
             const create = new StaticFunctionDecl(sinfo, this.m_penv.getCurrentFile(), [], "create", createdecl);
 
             const gkbody = new BodyImplementation(`${this.m_penv.getCurrentFile()}::${sinfo.pos}`, this.m_penv.getCurrentFile(), "idkey_getkey_composite");

--- a/impl/src/tooling/aot/cppbody_emitter.ts
+++ b/impl/src/tooling/aot/cppbody_emitter.ts
@@ -1773,21 +1773,7 @@ class CPPBodyEmitter {
                 break;
             }
             case "idkey_from_composite": {
-                const ptype = this.typegen.getMIRType(idecl.params[0].type);
-                let kvs: string[] = [];
-                //
-                //TODO: we chat and use the fact that tuples/records are also uniform representation to skip any coerce ops
-                //
-                if(ptype.options[0] instanceof MIRTupleType) {
-                    kvs = (ptype.options[0] as MIRTupleType).entries.map((e, i) => {
-                        return `${params[0]}.atFixed<${i}>()`;
-                    });
-                }
-                else {
-                    kvs = (ptype.options[0] as MIRRecordType).entries.map((e) => {
-                        return `${params[0]}.atFixed<MIRPropertyEnum::${e.name}>()`;
-                    });
-                }
+                const kvs = params.map((p, i) => this.typegen.coerce(p, this.typegen.getMIRType(idecl.params[i].type), this.typegen.keyType));
                 bodystr = `auto $$return = BSQIdKeyCompound{ { ${kvs.join(", ")} }, MIRNominalTypeEnum::${this.typegen.mangleStringForCpp(this.currentRType.trkey)} };`;
                 break;
             }

--- a/impl/src/tooling/bmc/smtbody_emitter.ts
+++ b/impl/src/tooling/bmc/smtbody_emitter.ts
@@ -1815,22 +1815,12 @@ class SMTBodyEmitter {
                 break;
             }
             case "idkey_from_composite": {
-                const ptype = this.typegen.getMIRType(idecl.params[0].type);
                 let kvs: string = "bsqidkey_array_empty";
-                if(ptype.options[0] instanceof MIRTupleType) {
-                    const tentries = (ptype.options[0] as MIRTupleType).entries;
-                    for (let i = 0; i < tentries.length; ++i) {
-                        const select = this.typegen.coerce(new SMTValue(`(select (bsq_tuple_entries ${params[0]}) ${i})`), this.typegen.anyType, this.typegen.keyType);
-                        kvs = `(store ${kvs} ${i} ${select.emit()})`;
-                    }
+                for (let i = 0; i < params.length; ++i) {
+                    const select = this.typegen.coerce(new SMTValue(params[i]), this.typegen.getMIRType(idecl.params[i].type), this.typegen.keyType);
+                    kvs = `(store ${kvs} ${i} ${select.emit()})`;
                 }
-                else {
-                    const rentries = (ptype.options[0] as MIRRecordType).entries;
-                    for (let i = 0; i < rentries.length; ++i) {
-                        const select = this.typegen.coerce(new SMTValue(`(select (bsq_record_entries ${params[0]}) "${rentries[i].name}")`), this.typegen.anyType, this.typegen.keyType);
-                        kvs = `(store ${kvs} ${i} ${select.emit()})`;
-                    }
-                }
+                
                 bodyres = new SMTValue(`(bsq_idkeycompound@cons MIRNominalTypeEnum_${this.typegen.mangleStringForSMT(enclkey)} ${kvs})`);
                 break;
             }


### PR DESCRIPTION
Revert partial of #274 -- keep original multi-arg signature for `create` method.