### PR TITLE
added sort function for List

### DIFF
--- a/impl/src/test/tests/library/listtests.bsq
+++ b/impl/src/test/tests/library/listtests.bsq
@@ -680,6 +680,16 @@ entrypoint function mapindexop(): Int {
     return 0;
 }
 
+entrypoint function sort(): Int {
+    let l = List<Int>@{2, 7, 8, 23, 0, 5, 9};
+    
+    let ll = l.sort(fn(a, b) => a < b);
+    check ll.size() == 7;
+    check ll.front() == 0;
+    check ll.back() == 23;
+
+    return 0;
+}
 
 
 

--- a/impl/src/tooling/aot/cppbody_emitter.ts
+++ b/impl/src/tooling/aot/cppbody_emitter.ts
@@ -1975,6 +1975,13 @@ class CPPBodyEmitter {
                 }
                 break;
             }
+            case "list_sort": {
+                const ltype = this.getEnclosingListTypeForListOp(idecl);
+                const ctype = this.getListContentsInfoForListOp(idecl);
+                const lambda = this.typegen.getFunctorsForType(ctype).less;
+                bodystr = `auto $$return = ${this.createListOpsFor(ltype, ctype)}::list_sort(${params[0]}, ${lambda}{});`
+                break;
+            }
             case "list_filter": {
                 const ltype = this.getEnclosingListTypeForListOp(idecl);
                 const ctype = this.getListContentsInfoForListOp(idecl);

--- a/impl/src/tooling/aot/runtime/bsqcustom/bsqlist_ops.h
+++ b/impl/src/tooling/aot/runtime/bsqcustom/bsqlist_ops.h
@@ -422,15 +422,15 @@ public:
     }
 
     template <typename LambdaCMP>
-    static Ty* list_sort(Ty* l)
+    static Ty* list_sort(Ty* l, LambdaCMP cmp)
     {
         std::vector<T> entries;
         entries.reserve(l->entries.size());
 
-        std::for_each(l->begin(), l->end(), [&entries](T& v) {
+        std::for_each(l->entries.begin(), l->entries.end(), [&entries](T& v) {
             entries.push_back(RCIncF{}(v));
         });
-        std::stable_sort(entries.begin(), entries.end(), LambdaCMP{});
+        std::stable_sort(entries.begin(), entries.end(), cmp);
 
         return BSQ_NEW_NO_RC(Ty, l->nominalType, move(entries));
     }


### PR DESCRIPTION
Fixes https://github.com/microsoft/BosqueLanguage/issues/290

Changes:
Implements List.sort. A test is also available. But it could be that my implementation is not the cleanest one, so please reject this PR if there is a better solution.

--EDIT: for now, only *less than* algorithm is supported as I am not sure how to properly "forward" the function given in the *sort* call. 
