### PR TITLE
fix: make List.sort accept function param

### DIFF
--- a/impl/src/tooling/aot/cppbody_emitter.ts
+++ b/impl/src/tooling/aot/cppbody_emitter.ts
@@ -1999,8 +1999,8 @@ class CPPBodyEmitter {
             case "list_sort": {
                 const ltype = this.getEnclosingListTypeForListOp(idecl);
                 const ctype = this.getListContentsInfoForListOp(idecl);
-                const lambda = this.typegen.getFunctorsForType(ctype).less;
-                bodystr = `auto $$return = ${this.createListOpsFor(ltype, ctype)}::list_sort(${params[0]}, ${lambda}{});`
+                const lambda = this.createLambdaFor(idecl.pcodes.get("cmp") as MIRPCode);
+                bodystr = `auto $$return = ${this.createListOpsFor(ltype, ctype)}::list_sort(${params[0]}, ${lambda});`
                 break;
             }
             case "list_filter": {


### PR DESCRIPTION
Fixes https://github.com/microsoft/BosqueLanguage/issues/296

Changes:
List.sort now accepts function parameter.
