### PR TITLE
fix: map's values function return type

### DIFF
--- a/impl/src/core/cpp/map.bsq
+++ b/impl/src/core/cpp/map.bsq
@@ -53,7 +53,7 @@ entity Map<K where KeyType, V> provides Object, Expandoable<MapEntry<K, V>>, POD
         return Map<K, V>::s_key_set(this);
     }
 
-    method values(): List<K> {
+    method values(): List<V> {
         return Map<K, V>::s_values(this);
     }
 
@@ -178,7 +178,7 @@ entity DynamicMap<K where KeyType, V> provides Object, Expandoable<MapEntry<K, V
         abort;
     }
 
-    method values(): List<K>  {
+    method values(): List<V>  {
         abort;
     }
 

--- a/impl/src/core/symbolic/map.bsq
+++ b/impl/src/core/symbolic/map.bsq
@@ -240,7 +240,7 @@ entity Map<K where KeyType, V> provides Object, Expandoable<MapEntry<K, V>>, POD
         return Map<K, V>::s_key_set(this);
     }
 
-    method values(): List<K> {
+    method values(): List<V> {
         return Map<K, V>::s_value_list(this, KeyList<K>::sort(Map<K, V>::s_get_keylist(this)), List<V>@{});
     }
 
@@ -365,7 +365,7 @@ entity DynamicMap<K where KeyType, V> provides Object, Expandoable<MapEntry<K, V
         abort;
     }
 
-    method values(): List<K>  {
+    method values(): List<V>  {
         abort;
     }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/BosqueLanguage/issues/302

Changes:
Map's **values()** methods from `cpp` and `symbolic` now have correct return value types.
