### PR TITLE
added script to make exegen.js globally available

### DIFF
--- a/impl/package-lock.json
+++ b/impl/package-lock.json
@@ -29,6 +29,16 @@
                 "supports-color": "^5.3.0"
             }
         },
+        "chmod": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/chmod/-/chmod-0.2.1.tgz",
+            "integrity": "sha1-3uccQg/AC/Uj1XKxSSL1XZGfnQo=",
+            "dev": true,
+            "requires": {
+                "deep-extend": "^0.2.8",
+                "stat-mode": "~0.1.0"
+            }
+        },
         "color-convert": {
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -48,6 +58,12 @@
             "version": "2.20.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
             "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+        },
+        "deep-extend": {
+            "version": "0.2.11",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
+            "integrity": "sha1-eha6aXKRMjQFBhcElLyD9wdv4I8=",
+            "dev": true
         },
         "escape-string-regexp": {
             "version": "1.0.5",
@@ -87,6 +103,27 @@
                 "graceful-fs": "^4.1.6"
             }
         },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+            "dev": true
+        },
+        "prepend-file": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/prepend-file/-/prepend-file-1.3.1.tgz",
+            "integrity": "sha1-g7FuC0rBkB/OiNvZRaIvTMgd9Xk=",
+            "dev": true,
+            "requires": {
+                "tmp": "0.0.31"
+            }
+        },
+        "stat-mode": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.1.0.tgz",
+            "integrity": "sha1-DPvsOvKeYFkSLS9+/D6WqCA1Vqk=",
+            "dev": true
+        },
         "supports-color": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -94,6 +131,15 @@
             "dev": true,
             "requires": {
                 "has-flag": "^3.0.0"
+            }
+        },
+        "tmp": {
+            "version": "0.0.31",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
+            "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
+            "dev": true,
+            "requires": {
+                "os-tmpdir": "~1.0.1"
             }
         },
         "universalify": {

--- a/impl/package.json
+++ b/impl/package.json
@@ -16,16 +16,22 @@
     },
     "devDependencies": {
         "chalk": "~2.4.2",
-        "fs-extra": "~8.1.0"
+        "chmod": "^0.2.1",
+        "fs-extra": "~8.1.0",
+        "prepend-file": "^1.3.1"
     },
     "scripts": {
         "build": "tsc -p tsconfig.json && node ./build/resource_copy.js",
-        "test": "tsc -p tsconfig.json && node ./build/resource_copy.js && node ./bin/test/test_runner.js"
+        "test": "tsc -p tsconfig.json && node ./build/resource_copy.js && node ./bin/test/test_runner.js",
+        "make-exe": "npm run build && node ./scripts/make-exe.js && npm link"
     },
     "files": [
         "bin/*"
     ],
     "engines": {
         "node": ">=10.0"
+    },
+    "bin": {
+        "exegen": "./bin/runtimes/exegen/exegen.js"
     }
 }

--- a/impl/scripts/make-exe.js
+++ b/impl/scripts/make-exe.js
@@ -1,0 +1,27 @@
+const prependFile = require('prepend-file');
+const chmod = require('chmod');
+const file = './bin/runtimes/exegen/exegen.js';
+
+prependFile(file, '#!/usr/bin/env node\n', function (err) {
+    if (err) {
+      console.log('Error while executing make-exe script: ' + err);
+    }
+});
+
+chmod(file, {
+  owner: {
+    read: true,
+    write: true,
+    execute: true
+  },
+  group: {
+    read: true,
+    write: true,
+    execute: true
+  },
+  others: {
+    read: true,
+    write: false,
+    execute: true
+  }
+});


### PR DESCRIPTION
Fixes https://github.com/microsoft/BosqueLanguage/issues/251

Changes:

This PR adds a new npm script `make-exe` that allows installation of globally available `exegen.js` script on the three main platforms: Windows, macOS and Linux. 

This script combines three calls:

* compilation of exegen.js with `npm run build`
* conversion of exegen.js into an executable by the new script `make-exe.js` located in `impl/scripts`
* execution of the standard `npm link` command that creates a platform-independent global symlink.

The exegen script can be called with or without extension (`js` on macOS/Linux and `cmd` on Windows).

**Windows**

![exegen_win](https://raw.githubusercontent.com/brakmic/bazaar/master/images/random/exegen_win.png)

**macOS**

![exegen_mac](https://raw.githubusercontent.com/brakmic/bazaar/master/images/random/exegen_mac.png)

**Linux**

![exegen_linux](https://raw.githubusercontent.com/brakmic/bazaar/master/images/random/exegen_linux_ubuntu.png)