### PR TITLE
remove redundant chmod npm package

### DIFF
--- a/impl/package-lock.json
+++ b/impl/package-lock.json
@@ -29,16 +29,6 @@
                 "supports-color": "^5.3.0"
             }
         },
-        "chmod": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/chmod/-/chmod-0.2.1.tgz",
-            "integrity": "sha1-3uccQg/AC/Uj1XKxSSL1XZGfnQo=",
-            "dev": true,
-            "requires": {
-                "deep-extend": "^0.2.8",
-                "stat-mode": "~0.1.0"
-            }
-        },
         "color-convert": {
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -58,12 +48,6 @@
             "version": "2.20.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
             "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
-        },
-        "deep-extend": {
-            "version": "0.2.11",
-            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
-            "integrity": "sha1-eha6aXKRMjQFBhcElLyD9wdv4I8=",
-            "dev": true
         },
         "escape-string-regexp": {
             "version": "1.0.5",
@@ -117,12 +101,6 @@
             "requires": {
                 "tmp": "0.0.31"
             }
-        },
-        "stat-mode": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.1.0.tgz",
-            "integrity": "sha1-DPvsOvKeYFkSLS9+/D6WqCA1Vqk=",
-            "dev": true
         },
         "supports-color": {
             "version": "5.5.0",

--- a/impl/package.json
+++ b/impl/package.json
@@ -16,14 +16,13 @@
     },
     "devDependencies": {
         "chalk": "~2.4.2",
-        "chmod": "^0.2.1",
         "fs-extra": "~8.1.0",
         "prepend-file": "^1.3.1"
     },
     "scripts": {
         "build": "tsc -p tsconfig.json && node ./build/resource_copy.js",
         "test": "tsc -p tsconfig.json && node ./build/resource_copy.js && node ./bin/test/test_runner.js",
-        "make-exe": "npm run build && node ./scripts/make-exe.js && npm link"
+        "make-exe": "npm run build && node ./scripts/make-exe.js && npm --force link"
     },
     "files": [
         "bin/*"

--- a/impl/scripts/make-exe.js
+++ b/impl/scripts/make-exe.js
@@ -1,27 +1,8 @@
 const prependFile = require('prepend-file');
-const chmod = require('chmod');
 const file = './bin/runtimes/exegen/exegen.js';
 
 prependFile(file, '#!/usr/bin/env node\n', function (err) {
     if (err) {
       console.log('Error while executing make-exe script: ' + err);
     }
-});
-
-chmod(file, {
-  owner: {
-    read: true,
-    write: true,
-    execute: true
-  },
-  group: {
-    read: true,
-    write: true,
-    execute: true
-  },
-  others: {
-    read: true,
-    write: false,
-    execute: true
-  }
 });


### PR DESCRIPTION
This PR removed the redundant npm package `chmod` from `make-exe` script.

Reference: https://github.com/microsoft/BosqueLanguage/issues/251#event-3445459405
