### PR TITLE
remove fixed clang paths in Windows

### DIFF
--- a/impl/src/runtimes/exegen/exegen.ts
+++ b/impl/src/runtimes/exegen/exegen.ts
@@ -58,7 +58,7 @@ function generateMASM(files: string[], blevel: "debug" | "test" | "release", cor
 program
     .option("-e --entrypoint [entrypoint]", "Entrypoint of the exe", "NSMain::main")
     .option("-o --outfile [outfile]", "Optional name of the output exe", (process.platform === "win32") ? "a.exe" : "a.out")
-    .option("-c --compiler [compiler]", "Compiler to use", (process.platform === "win32") ? "\"C:\\Program Files\\LLVM\\bin\\clang.exe\"" : "clang++")
+    .option("-c --compiler [compiler]", "Compiler to use", (process.platform === "win32") ? "clang.exe" : "clang++")
     .option("-l --level [level]", "Build level version", "debug")
     .option("-f --flags <flags>", "Custom compiler flags", "")
 

--- a/impl/src/runtimes/vscmd/vscmd.ts
+++ b/impl/src/runtimes/vscmd/vscmd.ts
@@ -27,7 +27,7 @@ else {
 }
 
 const z3path = Path.normalize(Path.join(__dirname, "../../tooling/bmc/runtime", platpathsmt));
-const compilerpath = (process.platform === "win32") ? "\"C:\\Program Files\\LLVM\\bin\\clang.exe\"" : "clang++";
+const compilerpath = (process.platform === "win32") ? "clang.exe" : "clang++";
 const binext = (process.platform === "win32") ? "exe" : "out";
 
 function checkMASM(files: string[], corelibpath: string, doemit: boolean): boolean {

--- a/impl/src/test/test_runner.ts
+++ b/impl/src/test/test_runner.ts
@@ -13,7 +13,7 @@ let platpathcpp: string | undefined = undefined;
 let platpathsmt: string | undefined = undefined;
 let platexe: string | undefined = undefined;
 if (process.platform === "win32") {
-    platpathcpp = "\"C:\\Program Files\\LLVM\\bin\\clang.exe\"";
+    platpathcpp = "clang.exe";
     platpathsmt = "bin/win/z3.exe";
     platexe = "doit.exe";
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/BosqueLanguage/issues/335

Changes:
This PR removes fixed `clang` paths in Windows (`C:\Program Files\LLVM\bin`). As the compiler binary will be searched via the system PATH anyway, there is no need to hardcode it. 