### PR TITLE
Add initial support for verification

### DIFF
--- a/impl/src/core/verify/core.bsq
+++ b/impl/src/core/verify/core.bsq
@@ -1,0 +1,493 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+//The core namespace implements the primitive types used in the Bosque language
+namespace NSCore;
+
+//<summary>Special type which all values are instances of.</summary>
+concept Any {
+    method is<T>(): Bool # special_method
+    method as<T>(): T # special_method
+
+    method tryAs<T>(): T? # special_method
+    method defaultAs<T>(default: T): T # special_method
+
+    method isNone(): Bool # special_method
+    method isSome(): Bool # special_method
+}
+
+//<summary>Special type for representing all non-none values.</summary>
+concept Some provides Any {
+    method update(): Some # special_method
+    method merge(): Some # special_method
+    method project<T>(): Some # special_method
+    method tryProject<T>(): Some? # special_method
+}
+
+//<summary>A marker concept that indicates a type has a convert method that will allow conversion to a supertype -- used for method override contravariance</summary>
+concept Convertable provides Any {
+}
+
+//<summary>Special type for indicating this type supports typed string use.</summary>
+concept Parsable provides Any {
+    abstract static tryParse(str: String): Result<Any, String>;
+}
+
+//<summary>Special type that all Validator (regex etc.) types provide.</summary>
+concept Validator provides Any {
+    abstract static accepts(str: String): Bool; 
+}
+
+//<summary>Special type for indicating a value can be used as a key in a collection.</summary>
+concept KeyType provides Any {
+    static equal(a: KeyType, b: KeyType): Bool # special_method
+    static less(a: KeyType, b: KeyType): Bool # special_method
+}
+
+//<summary>Type for indicating that a datatype is Plain-Old-Data.</summary>
+concept PODType provides APIType {
+    static bufferify<T where PODType>(data: T, format?: BufferFormat, encoding?: BufferEncoding, compression?: BufferCompression): Buffer<T> # pod_bufferify
+    static parseBuffer<T where PODType>(data: Buffer<T>): T # pod_parsebuffer
+    static tryParseBuffer<T where PODType>(data: Buffer<T>): Result<T, String> # pod_tryparsebuffer
+}
+
+//<summary>Type to unify Buffers and APITypes at top level for checking</summary>
+concept APIValue provides Any {
+}
+
+//<summary>Type for indicating that a datatype can be exported as part of a stable API.</summary>
+concept APIType provides APIValue {
+    static bufferify<T where APIType>(data: T, format?: BufferFormat, encoding?: BufferEncoding, compression?: BufferCompression): Buffer<T> # api_bufferify
+    static parseBuffer<T where APIType>(data: Buffer<T>): T # api_parsebuffer
+    static tryParseBuffer<T where APIType>(data: Buffer<T>): Result<T, String> # api_tryparsebuffer
+}
+
+//<summary>Type for representing the none-value.</summary>
+struct concept Truthy provides KeyType, Parsable {
+    static truth(v: Truthy): Bool {
+        return !!v;
+    }
+
+    override static tryParse(str: String): Result<Truthy, String> {
+        if(str == "none") {
+            return ok(none);
+        }
+        elif(str == "false") {
+            return ok(false);
+        }
+        elif(str == "true") {
+            return ok(true);
+        }
+        else {
+            return err("Expected Truthy");
+        }
+    }
+}
+
+//<summary>Type for representing the none-value.</summary>
+struct entity None provides Truthy, PODType, APIType {
+    override static tryParse(str: String): Result<None, String> {
+        if(str == "none") {
+            return ok(none);
+        }
+        else {
+            return err("Expected None");
+        }
+    }
+}
+
+//<summary>Primitive boolean value.</summary>
+struct entity Bool provides Some, Truthy, PODType, APIType {
+    override static tryParse(str: String): Result<Bool, String> {
+        if(str == "false") {
+            return ok(false);
+        }
+        elif(str == "true") {
+            return ok(true);
+        }
+        else {
+            return err("Expected Bool");
+        }
+    }
+
+    static stringify(b: Bool): String {
+        return b ? "true" : "false";
+    }
+    
+    static parse(str: String): Bool {
+        check str == "false" || str == "true";
+        return (str == "false") ? false : true;
+    }
+}
+
+//<summary>Primitive integer value.</summary>
+struct entity Int provides KeyType, Parsable, PODType, APIType, Some {
+    const min_value: Int = -9007199254740991;
+    const max_value: Int = 9007199254740991;
+
+    override static tryParse(str: String): Result<Int, String> # int_tryparse
+
+    static stringify(i: Int): String # int_tostring
+    static parse(str: String): Int # int_parse
+
+    static max(v1: Int, v2: Int): Int {
+        return v1 > v2 ? v1 : v2;
+    }
+
+    static min(v1: Int, v2: Int): Int {
+        return v1 < v2 ? v1 : v2;
+    }
+
+    static mod(a: Int, b: Int): Int # int_mod
+}
+
+//<summary>Primitive big-integer value.</summary>
+entity BigInt provides KeyType, Parsable, PODType, APIType, Some {
+    override static tryParse(str: String): Result<BigInt, String> # bigint_tryparse
+
+    static stringify(i: BigInt): String # bigint_tostring
+    static parse(str: String): BigInt # bigint_parse
+}
+
+//<summary>Primitive float 64 value.</summary>
+struct entity Float64 provides Parsable, PODType, APIType, Some {
+    hidden static s_float_min_value(): Float64 # float_min_value
+    hidden static s_float_max_value(): Float64 # float_max_value
+    hidden static s_float_infinity_value(): Float64 # float_infinity_value
+    hidden static s_float_nan_value(): Float64 # float_nan_value
+
+    const min_value: Float64 = Float64::s_float_min_value();
+    const max_value: Float64 = Float64::s_float_max_value();
+
+    const infinity: Float64 = Float64::s_float_infinity_value();
+    const nan: Float64 = Float64::s_float_nan_value();
+    
+    const pi: Float64 = 3.1415926535897931f;
+    const e: Float64 = 2.7182818284590451f;
+
+    override static tryParse(str: String): Result<Float64, String> # float64_tryparse
+
+    static stringify(f: Float64): String # float64_tostring
+    static parse(str: String): Float64 # float64_parse
+
+    method isInfinite(): Bool # float64_isinfinity
+    method isNan(): Bool # float64_isnan
+
+    static compare(a: Float64, b: Float64, eps?: Float64): Int # float64_compare
+
+    method abs(): Float64 # float64_abs
+    method ceiling(): Float64 # float64_ceiling
+    method floor(): Float64 # float64_floor
+
+    static pow(x: Float64, y: Float64): Float64 # float64_pow
+    static pow2(v: Float64): Float64 # float64_pow2
+    static pow10(v: Float64): Float64 # float64_pow10
+    static exp(y: Float64): Float64 # float64_exp
+
+    static root(x: Float64, y: Float64): Float64 # float64_root
+
+    method square(): Float64 # float64_square
+    method sqrt(): Float64 # float64_sqrt
+
+    static log(v: Float64): Float64 # float64_log
+    static log2(v: Float64): Float64 # float64_log2
+    static log10(v: Float64): Float64 # float64_log10
+
+    method sin(): Float64 # float64_sin
+    method cos(): Float64 # float64_cos
+    method tan(): Float64 # float64_tan
+
+    static min(v1: Float64, v2: Float64): Float64 # float64_min
+    static max(v1: Float64, v2: Float64): Float64 # float64_max
+
+    static sum(l: List<Float64>): Float64 # float64_sum
+    static product(l: List<Float64>): Float64 # float64_product
+}
+
+//<summary>Primitive string value.</summary>
+entity String provides KeyType, PODType, APIType, Some {
+    private static s_length(s: String): Int # string_count
+    private static s_charat(s: String): Int # string_charat
+
+    private static s_concat(s1: List<String>): String # string_concat
+
+    private static s_rangeInBounds(str: String, start: Int?, end: Int?): Bool {
+        let s, e = start ?| 0, end ?| String::s_length(str);
+        return 0 <= s && s <= e && e <= String::s_length(str);
+    }
+
+    private static s_substring(s: String, start: Int, end: Int): String # string_substring
+
+    method length(): Int {
+        return String::s_length(this);
+    }
+
+    method charAt(idx: Int): String
+        requires release 0 <= idx && idx < String::s_length(this);
+    {
+        return String::s_charat(this, idx);
+    }
+
+    static concat(...args: List<String>): String {
+        if(List<String>::s_size(args) == 0) {
+            return "";
+        }
+        elif(List<String>::s_size(args) == 1) {
+            return args.front();
+        }
+        else {
+            return String::s_concat(args);
+        }
+    }
+
+    method substring(start?: Int, end?: Int): String
+        requires release String::s_rangeInBounds(this, start, end);
+    {
+        let s, e = start ?| 0, end ?| String::s_length(this);
+        return String::s_substring(this, s, e);
+    }
+
+    method includes(str: String): Bool # string_includes
+    method startsWith(str: String): Bool # string_startswith
+    method endsWith(str: String): Bool # string_endswith
+
+    method indexOf(str: String): Int # string_indexof
+    method lastIndexOf(str: String): Int # string_indexof
+
+    method split(sep: String): List<String> # string_indexof
+    static join(sep: String, args: List<String>): String # string_join
+
+    method trim(): String # string_trim
+    method trimStart(): String # string_trimstart
+    method trimEnd(): String # string_trimend
+
+    static compare(a: String, b: String): Bool # string_compare
+}
+
+//<summary>Primitive safe string value.</summary>
+entity SafeString<T where Validator> provides KeyType, Some, PODType, APIType, Convertable {
+    private static s_unsafe_from(str: String): SafeString<T> # safestring_unsafe_from
+
+    method string(): String # safestring_string
+
+    static from(str: String): SafeString<T>
+        requires release T::accepts(str);
+    {
+        return SafeString<T>::s_unsafe_from(str);
+    }
+
+    static tryFrom(str: String): SafeString<T>? {
+        return T::accepts(str) ? SafeString<T>::s_unsafe_from(str) : none;
+    }
+
+    method convert<U where Validator>(): SafeString<U> # stringof_convert
+    method tryConvert<U where Validator>(): SafeString<U>? # stringof_tryconvert
+}
+
+//<summary>Primitive stringof value.</summary>
+entity StringOf<T where Parsable> provides APIValue, KeyType, Some, Convertable {
+    private static s_unsafe_from(str: String): StringOf<T> # stringof_unsafe_from
+
+    method string(): String # stringof_string
+
+    static from(str: String): StringOf<T> 
+        requires release T::tryParse(str).isOk();
+    {
+        return StringOf<T>::s_unsafe_from(str);
+    }
+
+    static tryFrom(str: String): StringOf<T>? {
+        return T::tryParse(str).isOk() ? StringOf<T>::s_unsafe_from(str) : none;
+    }
+
+    method convert<U where Parsable>(): StringOf<U> # stringof_convert
+    method tryConvert<U where Parsable>(): StringOf<U>? # stringof_tryconvert
+}
+
+//<summary>An efficient buffer encoding for data.</summary>
+entity Buffer<T where PODType | APIType> provides APIValue, Some {
+    method bytes(): ByteBuffer # buffer_bytes
+}
+
+//<summary>An efficient buffer encoding for data.</summary>
+entity BufferOf<T where Parsable> provides APIValue, Some {
+    method bytes(): ByteBuffer # bufferof_bytes
+}
+
+enum BufferFormat {
+    char,
+    bosque,
+    ebosque,
+    json
+}
+
+enum BufferEncoding {
+    utf8,
+    uri,
+    base64,
+    binary
+}
+
+enum BufferCompression {
+    off,
+    rle,
+    time,
+    space
+}
+
+//<summary>An efficient byte buffer for data.</summary>
+entity ByteBuffer provides APIValue, Some {
+}
+
+//<summary>Primitive ISO standard date time value.</summary>
+struct entity ISOTime provides Parsable, PODType, APIType, Some {
+    override static tryParse(str: String): Result<ISOTime, String> # time_tryparse
+}
+
+//<summary>Primitive UUID value.</summary>
+struct entity UUID provides KeyType, Parsable, PODType, APIType, Some {
+    override static tryParse(str: String): Result<UUID, String> # uuid_tryparse
+}
+
+//<summary>All actual ordered event times implicitly provide this.</summary>
+struct entity LogicalTime provides KeyType, Parsable, PODType, APIType, Some {
+    override static tryParse(str: String): Result<LogicalTime, String> # logicaltime_tryparse
+
+    static zero(): LogicalTime # logicaltime_zero
+    static tick(t: LogicalTime): LogicalTime # logicaltime_tick
+}
+
+//<summary>Primitive hash value suitable for content addressable operations or crypto secure digests.</summary>
+entity CryptoHash provides KeyType, Parsable, PODType, APIType, Some {
+    static compute<T>(value: T): CryptoHash # cryptohash_compute
+
+    override static tryParse(str: String): Result<CryptoHash, String> # cryptohash_tryparse
+}
+
+//<summary>All actual enums implicitly provide this.</summary>
+concept Enum provides KeyType, Some {
+}
+
+//<summary>All actual custom keys implicitly provide this.</summary>
+concept IdKey provides KeyType, Some {
+}
+
+//<summary>Primitive regex value.</summary>
+entity Regex provides Some {
+    hidden static s_accepts(str: String, start: Int, end: Int): Bool # regex_accepts
+    hidden static s_match(str: String, start: Int, end: Int): Int, Int # regex_match
+
+    hidden static s_rangeInBounds(str: String, start: Int?, end: Int?): Bool {
+        let s, e = start ?| 0, end ?| String::s_length(str);
+        return 0 <= s && s <= e && e <= String::s_length(str); 
+    }
+
+    method accepts(str: String, start?: Int, end?: Int): Bool
+        requires release Regex::s_rangeInBounds(s, start, end);
+    {
+        let s, e = start ?| 0, end ?| String::s_length(str);
+        return Regex::s_accepts(str, s, e);
+    }
+
+    method match(str: String, start?: Int, end?: Int): RegexMatch
+        requires release Regex::s_rangeInBounds(s, start, end);
+    {
+        let s, e = start ?| 0, end ?| String::s_length(str);
+
+        let i, l = Regex::s_match(str, s, e);
+        if(l == -1) {
+            return RegexMatch@{ success=false, index=-1, length=-1 };
+        }
+        else {
+            return RegexMatch@{ success=true, index=i, length=l };
+        }
+    }
+}
+
+entity RegexMatch provides Object {
+    field success: Bool;
+    field index: Int;
+    field length: Int;
+}
+
+//<summary>All actual tuples implicitly provide this concept.</summary>
+concept Tuple provides Some {
+}
+
+//<summary>All actual records implicitly provide this concept.</summary>
+concept Record provides Some {
+}
+
+struct entity MapEntry<K where KeyType, V> provides Some, Convertable, PODType when K PODType && V PODType, APIType when K APIType && V APIType {
+    field key: K;
+    field value: V;
+
+    static create(k: K, v: V): MapEntry<K, V> {
+        return MapEntry<K, V>@{ key=key, value=value };
+    }
+
+    method convert<T where KeyType, U>(): MapEntry<T, U> {
+        return MapEntry<T, U>@{ key=this.key.as<T>(), value=this.value.as<U>() };
+    }
+}
+
+//<summary>Providing this concept allows for an entity to be compared or stored in a key based container using the key field.</summary>
+struct concept Result<T, E=None> provides Some, Convertable, PODType when T PODType && E PODType, APIType when T APIType && E APIType {   
+    static createOk(result: T): Result<T, E> {
+        return Ok<T, E>::of(result);
+    }
+
+    static createErr(info: E): Result<T, E> {
+        return Err<T, E>::of(info);
+    }
+
+    method isOk(): Bool {
+        return this.is<Ok<T, E>>();
+    }
+
+    method isErr(): Bool {
+        return this.is<Err<T, E>>();
+    }
+
+    method result(): T {
+        return this.as<Ok<T, E>>().result;
+    }
+
+    method failure(): E {
+        return this.as<Err<T, E>>().failure;
+    }
+
+    method convert<U, V>(): Result<U, V> {
+        return this.isOk() ? Result<U, V>::createOk(this.result().as<U>()) : Result<U, V>::createErr(this.failure().as<V>());
+    }
+}
+
+struct entity Ok<T, E=None> provides Result<T, E> {
+    field result: T;
+
+    static of(result: T): Ok<T, E> {
+        return Ok<T, E>@{ result = result };
+    }
+}
+
+struct entity Err<T, E=None> provides Result<T, E> {
+    field failure: E;
+
+    static of(failure: E): Err<T, E> {
+        return Err<T, E>@{ failure = failure };
+    }
+}
+
+function ok(of: Any): Any # special_method
+function err(of: Any): Any # special_method
+
+//<summary>All actual entities/concepts implicitly provide this concept.</summary>
+concept Object provides Some {
+}
+
+//<summary>All collections provide this concept so we can expand them with spread operators.</summary>
+concept Expandoable<T> provides Object {
+    method expand<U>(): List<U> # special_method
+}

--- a/impl/src/core/verify/iteration.bsq
+++ b/impl/src/core/verify/iteration.bsq
@@ -1,0 +1,14 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+//The core namespace implements the primitive concepts used in the bosque core language
+namespace NSIterate;
+
+recursive? function while<S>(initial: S, step: recursive? fn(s: S) -> S, cond: recursive? fn(s: S) -> Bool): S # iteration_while
+recursive? function until<S>(initial: S, step: recursive? fn(s: S) -> S, cond: recursive? fn(s: S) -> Bool): S # iteration_until
+
+recursive? function steps<S>(initial: S, k: Int, step: recursive? fn(s: S) -> S): S # iteration_steps
+
+recursive? function reduce<T>(initial: T, vals: List<T>, op: recursive? fn(a: T, b: T) -> T, commutative?: Bool): T # iteration_reduce

--- a/impl/src/core/verify/list.bsq
+++ b/impl/src/core/verify/list.bsq
@@ -1,0 +1,567 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+//The core namespace implements the primitive concepts used in the bosque core language
+namespace NSCore;
+
+entity List<T> provides Object, Expandoable<T>, PODType when T PODType, APIType when T APIType {
+    hidden static s_size(l: List<T>): Int # list_size
+    hidden static s_unsafe_get(l: List<T>, i: Int): T # list_unsafe_get
+
+    hidden static s_concat(l: List<List<T>>): List<T> # list_concat
+    hidden static s_fill(k: Int, val: T): List<T> # list_fill
+
+    hidden static {when T KeyType} s_toset(l: List<T>): Set<T> # list_toset
+
+    hidden recursive? static s_all(l: List<T>, p: recursive? fn(_: T) -> Bool): Bool # list_all
+    hidden recursive? static s_none(l: List<T>, p: recursive? fn(_: T) -> Bool): Bool # list_none
+    hidden recursive? static s_any(l: List<T>, p: recursive? fn(_: T) -> Bool): Bool # list_any
+
+    hidden recursive? static s_count(l: List<T>, p: recursive? fn(_: T) -> Bool): Int # list_count
+    hidden recursive? static s_countnot(l: List<T>, p: recursive? fn(_: T) -> Bool): Int # list_countnot
+
+    hidden recursive? static s_indexof(l: List<T>, s: Int, e: Int, p: recursive? fn(_: T) -> Bool): Int # list_indexof
+    hidden recursive? static s_indexoflast(l: List<T>, s: Int, e: Int, p: recursive? fn(_: T) -> Bool): Int # list_indexoflast
+
+    hidden recursive? static s_indexofnot(l: List<T>, s: Int, e: Int, p: recursive? fn(_: T) -> Bool): Int # list_indexofnot
+    hidden recursive? static s_indexoflastnot(l: List<T>, s: Int, e: Int, p: recursive? fn(_: T) -> Bool): Int # list_indexoflastnot
+
+    hidden recursive? static {when T KeyType} s_count_keytype(l: List<T>, v: T): Int # list_count_keytype
+    hidden recursive? static {when T KeyType} s_indexof_keytype(l: List<T>, s: Int, e: Int, v: T): Int # list_indexof_keytype
+    hidden recursive? static {when T KeyType} s_indexoflast_keytype(l: List<T>, s: Int, e: Int, v: T): Int # list_indexoflast_keytype
+
+    hidden recursive? static {when T KeyType} s_min(l: List<T>): T # list_min
+    hidden recursive? static {when T KeyType} s_max(l: List<T>): T # list_max
+    hidden recursive? static {when T Int | BigInt} s_sum(l: List<T>): T # list_sum
+
+    hidden recursive? static s_filter(l: List<T>, p: recursive? fn(_: T) -> Bool): List<T> # list_filter
+    hidden recursive? static s_filternot(l: List<T>, p: recursive? fn(_: T) -> Bool): List<T> # list_filternot
+
+    hidden recursive? static s_oftype<U>(l: List<T>): List<U> # list_oftype
+    hidden recursive? static s_cast<U>(l: List<T>): List<U> # list_cast
+    hidden recursive? static s_slice(l: List<T>, s: Int, e: Int): List<T> # list_slice
+
+    hidden recursive? static s_takewhile(l: List<T>, p: recursive? fn(_: T) -> Bool): List<T> # list_takewhile
+    hidden recursive? static s_discardwhile(l: List<T>, p: recursive? fn(_: T) -> Bool): List<T> # list_discardwhile
+    hidden recursive? static s_takeuntil(l: List<T>, p: recursive? fn(_: T) -> Bool): List<T> # list_takeuntil
+    hidden recursive? static s_discarduntil(l: List<T>, p: recursive? fn(_: T) -> Bool): List<T> # list_discarduntil
+
+    hidden static {when T KeyType} s_unique(l: List<T>): List<T> # list_unique
+    hidden static s_reverse(l: List<T>): List<T> # list_reverse
+    
+    hidden recursive? static s_map<U>(l: List<T>, f: recursive? fn(_: T) -> U): List<U> # list_map
+    hidden recursive? static s_mapindex<U>(l: List<T>, f: recursive? fn(_: T, _: Int) -> U): List<U> # list_mapindex
+
+    hidden static {when T KeyType} s_projectWMap<U>(l: List<T>, m: Map<T, U>): List<U> # list_project
+    hidden static {when T KeyType} s_tryProjectWMap<U>(l: List<T>, m: Map<T, U>): List<U?> # list_tryproject
+    hidden static {when T KeyType} s_defaultProjectWMap<U>(l: List<T>, m: Map<T, U>, d: U): List<U> # list_defaultproject
+
+    hidden static  s_zipindex(l: List<T>): List<[Int, T]> # list_zipindex
+
+    hidden recursive? static s_join<U>(l: List<T>, ol: List<U>, p: recursive? fn(_: T, _: U) -> Bool): List<[T, U]> # list_join
+    hidden recursive? static s_joingroup<U>(l: List<T>, ol: List<U>, p: recursive? fn(_: T, _: U) -> Bool): List<[T, List<U>]> # list_joingroup
+
+    hidden static s_append(l: List<T>, lp: List<T>): List<T> # list_append
+
+    hidden recursive? static s_partition<K where KeyType>(l: List<T>, pf: recursive? fn(_: T) -> K): Map<K, List<T>> # list_partition
+    hidden recursive? static s_sort(l: List<T>, cmp: recursive? fn(_: T, _: T) -> Bool): List<T> # list_sort
+
+    hidden static s_toIndexMap(l: List<T>): Map<Int, T> # list_toindexmap
+    hidden recursive? static s_transformIndexMap<V>(l: List<T>, vf: recursive? fn(_: T) -> V): Map<Int, V> # list_transformindexmap
+    hidden recursive? static s_transformMap<K where KeyType, V>(l: List<T>, kf: recursive? fn(_: T) -> K, vf: recursive? fn(_: T) -> V): Map<K, V> # list_transformmap
+
+    hidden static s_rangeInBounds(l: List<T>, start: Int?, end: Int?): Bool {
+        let s, e = start ?| 0, end ?| List<T>::s_size(l);
+        return 0 <= s && s <= e && e <= List<T>::s_size(l);
+    }
+
+    static concat(...ll: List<List<T>>): List<T> {
+        return List<T>::s_concat(ll);
+    }
+
+    static fill(k: Int, val: T): List<T>
+        requires release k >= 0;
+    {
+        return List<T>::s_fill(k, val);
+    }
+
+    method size(): Int {
+        return List<T>::s_size(this);
+    }
+
+    method empty(): Bool {
+        return List<T>::s_size(this) == 0;
+    }
+
+    method front(): T 
+        requires release List<T>::s_size(this) != 0;
+    {
+        return List<T>::s_unsafe_get(this, 0);
+    }
+
+    method tryFront(): T? {
+        return List<T>::s_size(this) != 0 ? List<T>::s_unsafe_get(this, 0) : none;
+    }
+
+    method defaultFront(default: T): T {
+        return List<T>::s_size(this) != 0 ? List<T>::s_unsafe_get(this, 0) : default;
+    }
+
+    method back(): T 
+        requires release List<T>::s_size(this) != 0;
+    {
+        return List<T>::s_unsafe_get(this, List<T>::s_size(this) - 1);
+    }
+
+    method tryBack(): T? {
+        return List<T>::s_size(this) != 0 ? List<T>::s_unsafe_get(this, List<T>::s_size(this) - 1) : none;
+    }
+
+    method defaultBack(default: T): T {
+        return List<T>::s_size(this) != 0 ? List<T>::s_unsafe_get(this, List<T>::s_size(this) - 1) : default;
+    }
+
+    method get(i: Int): T 
+        requires release 0 <= i && i < List<T>::s_size(this);
+    {
+        return List<T>::s_unsafe_get(this, i);
+    }
+
+    method tryGet(i: Int): T? 
+        requires release 0 <= i;
+    {
+        return i < List<T>::s_size(this) ? List<T>::s_unsafe_get(this, i) : none;
+    }
+
+    method defaultGet(i: Int, default: T): T
+        requires release 0 <= i;
+    {
+        return i < List<T>::s_size(this) ? List<T>::s_unsafe_get(this, i) : default;
+    }
+
+    method {when T KeyType} toSet(): Set<T> {
+        return List<T>::s_toset(this);
+    }
+
+    recursive? method single(p: recursive? fn(_: T) -> Bool): T 
+        requires release List<T>::s_size(this) != 0;
+    {
+        let idx = List<T>::s_indexof[recursive?](this, 0, List<T>::s_size(this), p);
+        let lastidx = List<T>::s_indexoflast[recursive?](this, -1, List<T>::s_size(this) - 1, p);
+
+        check lastidx == idx;
+        return List<T>::s_unsafe_get(this, idx);
+    }
+
+    recursive? method trySingle(p: recursive? fn(_: T) -> Bool): T? {
+        let idx = List<T>::s_indexof[recursive?](this, 0, List<T>::s_size(this), p);
+        let lastidx = List<T>::s_indexoflast[recursive?](this, -1, List<T>::s_size(this) - 1, p);
+
+        return idx == lastidx ? List<T>::s_unsafe_get(this, idx) : none;
+    }
+
+    recursive? method defaultSingle(default: T, p: recursive? fn(_: T) -> Bool): T {
+        let idx = List<T>::s_indexof[recursive?](this, 0, List<T>::s_size(this), p);
+        let lastidx = List<T>::s_indexoflast[recursive?](this, -1, List<T>::s_size(this) - 1, p);
+
+        return idx == lastidx ? List<T>::s_unsafe_get(this, idx) : default;
+    }
+
+    method uniform(i: Int, start?: Int, end?: Int): T
+        requires release List<T>::s_size(this) != 0;
+        requires release List<T>::s_rangeInBounds(this, start, end);
+    {
+        abort;
+    }
+
+    recursive? method allOf(p: recursive? fn(_: T) -> Bool): Bool {
+        return List<T>::s_size(this) == 0 || List<T>::s_all[recursive?](this, p);
+    }
+
+    recursive? method noneOf(p: recursive? fn(_: T) -> Bool): Bool {
+        return List<T>::s_size(this) == 0 || List<T>::s_none[recursive?](this, p);
+    }
+
+    recursive? method anyOf(p: recursive? fn(_: T) -> Bool): Bool {
+        return List<T>::s_size(this) != 0 && List<T>::s_any[recursive?](this, p);
+    }
+
+    recursive? method countIf(p: recursive? fn(_: T) -> Bool): Int {
+        return List<T>::s_count[recursive?](this, p);
+    }
+
+    recursive? method countIfNot(p: recursive? fn(_: T) -> Bool): Int {
+        return List<T>::s_countnot[recursive?](this, p);
+    }
+
+    method {when T KeyType} contains(v: T): Bool {
+        return List<T>::s_indexof_keytype(this, 0, List<T>::s_size(this), v) != List<T>::s_size(this);
+    }
+
+    method {when T KeyType} count(v: T): Int {
+        return List<T>::s_count_keytype(this, v);
+    }
+
+    method {when T KeyType} min(): T 
+        requires release List<T>::s_size(this) != 0;
+    {
+        return List<T>::s_min(this);
+    }
+
+    method {when T KeyType} tryMin(): T? {
+        return List<T>::s_size(this) != 0 ? List<T>::s_min(this) : none;
+    }
+
+    method {when T KeyType} defaultMin(default: T): T {
+        return List<T>::s_size(this) != 0 ? List<T>::s_min(this) : default;
+    }
+
+    method {when T KeyType} max(): T 
+        requires release List<T>::s_size(this) != 0;
+    {
+        return List<T>::s_max(this);
+    }
+
+    method {when T KeyType} tryMax(): T? {
+        return List<T>::s_size(this) != 0 ? List<T>::s_max(this) : none;
+    }
+
+    method {when T KeyType} defaultMax(default: T): T {
+        return List<T>::s_size(this) != 0 ? List<T>::s_max(this) : default;
+    }
+
+    //
+    //TODO: should do argMin/argMax variations on these as well
+    //
+
+    method {when T Int | BigInt} sum(): T {
+        return List<T>::s_sum(this);
+    }
+
+    recursive? method find(p: recursive? fn(_: T) -> Bool): T {
+        let idx = List<T>::s_indexof[recursive?](this, 0, List<T>::s_size(this), p);
+        check idx != List<T>::s_size(this);
+        return List<T>::s_unsafe_get(this, idx);
+    }
+
+    recursive? method tryFind(p: recursive? fn(_: T) -> Bool): T? {
+        let idx = List<T>::s_indexof[recursive?](this, 0, List<T>::s_size(this), p);
+        return idx != List<T>::s_size(this) ? List<T>::s_unsafe_get(this, idx) : none;
+    }
+
+    recursive? method defaultFind(default: T, p: recursive? fn(_: T) -> Bool): T {
+        let idx = List<T>::s_indexof[recursive?](this, 0, List<T>::s_size(this), p);
+        return idx != List<T>::s_size(this) ? List<T>::s_unsafe_get(this, idx) : default;
+    }
+
+    recursive? method findNot(p: recursive? fn(_: T) -> Bool): T {
+        let idx = List<T>::s_indexofnot[recursive?](this, 0, List<T>::s_size(this), p);
+        check idx != List<T>::s_size(this);
+        return List<T>::s_unsafe_get(this, idx);
+    }
+
+    recursive? method tryFindNot(p: recursive? fn(_: T) -> Bool): T? {
+        let idx = List<T>::s_indexofnot[recursive?](this, 0, List<T>::s_size(this), p);
+        return idx != List<T>::s_size(this) ? List<T>::s_unsafe_get(this, idx) : none;
+    }
+
+    recursive? method defaultFindNot(default: T, p: recursive? fn(_: T) -> Bool): T {
+        let idx = List<T>::s_indexofnot[recursive?](this, 0, List<T>::s_size(this), p);
+        return idx != List<T>::s_size(this) ? List<T>::s_unsafe_get(this, idx) : default;
+    }
+
+    recursive? method findLast(p: recursive? fn(_: T) -> Bool): T {
+        let idxlast = List<T>::s_indexoflast[recursive?](this, -1, List<T>::s_size(this) - 1, p);
+        check idxlast != -1;
+        return List<T>::s_unsafe_get(this, idxlast);
+    }
+
+    recursive? method tryFindLast(p: recursive? fn(_: T) -> Bool): T? {
+        let idxlast = List<T>::s_indexoflast[recursive?](this, -1, List<T>::s_size(this) - 1, p);
+        return idxlast != -1 ? List<T>::s_unsafe_get(this, idxlast) : none;
+    }
+
+    recursive? method defaultFindLast(default: T, p: recursive? fn(_: T) -> Bool): T {
+        let idxlast = List<T>::s_indexoflast[recursive?](this, -1, List<T>::s_size(this) - 1, p);
+        return idxlast != -1 ? List<T>::s_unsafe_get(this, idxlast) : default;
+    }
+
+    recursive? method findLastNot(p: recursive? fn(_: T) -> Bool): T {
+        let idxlast = List<T>::s_indexoflastnot[recursive?](this, -1, List<T>::s_size(this) - 1, p);
+        check idxlast != -1;
+        return List<T>::s_unsafe_get(this, idxlast);
+    }
+
+    recursive? method tryFindLastNot(p: recursive? fn(_: T) -> Bool): T? {
+        let idxlast = List<T>::s_indexoflastnot[recursive?](this, -1, List<T>::s_size(this) - 1, p);
+        return idxlast != -1 ? List<T>::s_unsafe_get(this, idxlast) : none;
+    }
+
+    recursive? method defaultFindLastNot(default: T, p: recursive? fn(_: T) -> Bool): T {
+        let idxlast = List<T>::s_indexoflastnot[recursive?](this, -1, List<T>::s_size(this) - 1, p);
+        return idxlast != -1 ? List<T>::s_unsafe_get(this, idxlast) : default;
+    }
+
+    recursive? method findIndexOf(p: recursive? fn(_: T) -> Bool, start?: Int, end?: Int): Int
+        requires release List<T>::s_rangeInBounds(this, start, end);
+    {
+        let s, e = start ?| 0, end ?| List<T>::s_size(this);
+
+        let idx = List<T>::s_indexof[recursive?](this, s, e, p);
+        check idx != e;
+        return idx;
+    }
+
+    recursive? method tryFindIndexOf(p: recursive? fn(_: T) -> Bool, start?: Int, end?: Int): Int?
+        requires release List<T>::s_rangeInBounds(this, start, end);
+    {
+        let s, e = start ?| 0, end ?| List<T>::s_size(this);
+
+        let idx = List<T>::s_indexof[recursive?](this, s, e, p);
+        return idx != e ? idx : none;
+    }
+
+    recursive? method findIndexOfNot(p: recursive? fn(_: T) -> Bool, start?: Int, end?: Int): Int
+        requires release List<T>::s_rangeInBounds(this, start, end);
+    {
+        let s, e = start ?| 0, end ?| List<T>::s_size(this);
+
+        let idx = List<T>::s_indexofnot[recursive?](this, s, e, p);
+        check idx != e;
+        return idx;
+    }
+
+    recursive? method tryFindIndexOfNot(p: recursive? fn(_: T) -> Bool, start?: Int, end?: Int): Int?
+        requires release List<T>::s_rangeInBounds(this, start, end);
+    {
+        let s, e = start ?| 0, end ?| List<T>::s_size(this);
+
+        let idx = List<T>::s_indexofnot[recursive?](this, s, e, p);
+        return idx != e ? idx : none;
+    }
+
+    recursive? method findLastIndexOf(p: recursive? fn(_: T) -> Bool, start?: Int, end?: Int): Int
+        requires release List<T>::s_rangeInBounds(this, start, end);
+    {
+        let s, e = (start ?| 0) - 1, (end ?| List<T>::s_size(this)) - 1;
+
+        let idxlast = List<T>::s_indexoflast[recursive?](this, s, e, p);
+        check idxlast != s;
+        return idxlast;
+    }
+
+    recursive? method tryFindLastIndexOf(p: recursive? fn(_: T) -> Bool, start?: Int, end?: Int): Int?
+        requires release List<T>::s_rangeInBounds(this, start, end);
+    {
+        let s, e = (start ?| 0) - 1, (end ?| List<T>::s_size(this)) - 1;
+
+        let idxlast = List<T>::s_indexoflast[recursive?](this, s, e, p);
+        return idxlast != s ? idxlast : none;
+    }
+
+    recursive? method findLastIndexOfNot(p: recursive? fn(_: T) -> Bool, start?: Int, end?: Int): Int
+        requires release List<T>::s_rangeInBounds(this, start, end);
+    {
+        let s, e = (start ?| 0) - 1, (end ?| List<T>::s_size(this)) - 1;
+
+        let idxlast = List<T>::s_indexoflastnot[recursive?](this, s, e, p);
+        check idxlast != s;
+        return idxlast;
+    }
+
+    recursive? method tryFindLastIndexOfNot(p: recursive? fn(_: T) -> Bool, start?: Int, end?: Int): Int?
+        requires release List<T>::s_rangeInBounds(this, start, end);
+    {
+        let s, e = (start ?| 0) - 1, (end ?| List<T>::s_size(this)) - 1;
+
+        let idxlast = List<T>::s_indexoflastnot[recursive?](this, s, e, p);
+        return idxlast != s ? idxlast : none;
+    }
+
+    method {when T KeyType} indexOf(v: T, start?: Int, end?: Int): Int
+        requires release List<T>::s_rangeInBounds(this, start, end);
+    {
+        let s, e = start ?| 0, end ?| List<T>::s_size(this);
+
+        let idx = List<T>::s_indexof_keytype(this, s, e, v);
+        check idx != e;
+        return idx;
+    }
+
+    method {when T KeyType} tryIndexOf(v: T, start?: Int, end?: Int): Int?
+        requires release List<T>::s_rangeInBounds(this, start, end);
+    {
+        let s, e = start ?| 0, end ?| List<T>::s_size(this);
+
+        let idx = List<T>::s_indexof_keytype(this, s, e, v);
+        return idx != e ? idx : none;
+    }
+
+    method {when T KeyType} lastIndexOf(v: T, start?: Int, end?: Int): Int
+        requires release List<T>::s_rangeInBounds(this, start, end);
+    {
+        let s, e = (start ?| 0) - 1, (end ?| List<T>::s_size(this)) - 1;
+
+        let idx = List<T>::s_indexoflast_keytype(this, s, e, v);
+        check idx != s;
+        return idx;
+    }
+
+    method {when T KeyType} tryLastIndexOf(v: T, start?: Int, end?: Int): Int?
+        requires release List<T>::s_rangeInBounds(this, start, end);
+    {
+        let s, e = (start ?| 0) - 1, (end ?| List<T>::s_size(this)) - 1;
+
+        let idx = List<T>::s_indexoflast_keytype(this, s, e, v);
+        return idx != s ? idx : none;
+    }
+
+    recursive? method filter(p: recursive? fn(_: T) -> Bool): List<T> {
+        return List<T>::s_filter[recursive?](this, p);
+    }
+
+    recursive? method filterNot(p: recursive? fn(_: T) -> Bool): List<T> {
+        return List<T>::s_filternot[recursive?](this, p);
+    }
+
+    method ofType<U>(): List<U> {
+        return List<T>::s_oftype<U>(this);
+    }
+
+    method cast<U>(): List<U> {
+        return List<T>::s_cast<U>(this);
+    }
+
+    method slice(start?: Int, end?: Int): List<T> 
+        requires release List<T>::s_rangeInBounds(this, start, end);
+    {
+        let s, e = start ?| 0, end ?| List<T>::s_size(this);
+
+        if(s == e) {
+            return List<T>@{};
+        }
+        else {
+            return List<T>::s_slice(this, s, e);
+        }
+    }
+
+    method removeFirst(k: Int): List<T> 
+        requires release List<T>::s_rangeInBounds(this, k, List<T>::s_size(this));
+    {
+        return List<T>::s_slice(this, k, List<T>::s_size(this));
+    }
+
+    method removeLast(k: Int): List<T> 
+        requires release List<T>::s_rangeInBounds(this, k, List<T>::s_size(this));
+    {
+        return List<T>::s_slice(this, 0, List<T>::s_size(this) - k);
+    }
+
+    recursive? method takeWhile(p: recursive? fn(_: T) -> Bool): List<T> {
+        return List<T>::s_takewhile[recursive?](this, p);
+    }
+
+    recursive? method discardWhile(p: recursive? fn(_: T) -> Bool): List<T> {
+        return List<T>::s_discardwhile[recursive?](this, p);
+    }
+
+    recursive? method takeUntil(p: recursive? fn(_: T) -> Bool): List<T> {
+        return List<T>::s_takeuntil[recursive?](this, p);
+    }
+
+    recursive? method discardUntil(p: recursive? fn(_: T) -> Bool): List<T> {
+        return List<T>::s_discarduntil[recursive?](this, p);
+    }
+
+    method {when T KeyType} unique(): List<T> {
+        return List<T>::s_unique(this);
+    }
+
+    method reverse(): List<T> {
+        return List<T>::s_reverse(this);
+    }
+
+    recursive? method map<U>(f: recursive? fn(_: T) -> U): List<U> {
+        return List<T>::s_map<U>[recursive?](this, f);
+    }
+
+    recursive? method mapIndex<U>(f: recursive? fn(_: T, _: Int) -> U): List<U> {
+        return List<T>::s_mapindex<U>[recursive?](this, f);
+    }
+
+    method {when T KeyType} projectWithMap<U>(m: Map<T, U>): List<U> {
+        return List<T>::s_projectWMap<U>(this, m); 
+    }
+
+    method {when T KeyType} tryProjectWithMap<U>(m: Map<T, U>): List<U?> {
+        return List<T>::s_tryProjectWMap<U>(this, m);
+    }
+
+    method {when T KeyType} defaultProjectWithMap<U>(default: U, m: Map<T, U>): List<U> {
+        return List<T>::s_defaultProjectWMap<U>(this, m, default);
+    }
+
+    method zipIndex(): List<[Int, T]> {
+        return List<T>::s_zipindex(this);
+    }
+
+    recursive? method join<U>(ol: List<U>, p: recursive? fn(_: T, _: U) -> Bool): List<[T, U]> {
+        return List<T>::s_join<U>[recursive?](this, ol, p);
+    }
+
+    recursive? method joinGroup<U>(ol: List<U>, p: recursive? fn(_: T, _: U) -> Bool): List<[T, List<U>]> {
+        return List<T>::s_joingroup<U>[recursive?](this, ol, p);
+    }
+
+    method append(l: List<T>): List<T> {
+        return List<T>::s_append(this, l);
+    }
+
+    method prepend(l: List<T>): List<T> {
+        return List<T>::s_append(l, this);
+    }
+
+    recursive? method partition<K where KeyType>(pf: recursive? fn(_: T) -> K): Map<K, List<T>> {
+        return List<T>::s_partition<K>[recursive?](this, pf);
+    }
+
+    recursive? method sort(cmp: recursive? fn(_: T, _: T) -> Bool): List<T> {
+        return List<T>::s_sort[recursive?](this, cmp);
+    }
+
+    method toIndexMap(): Map<Int, T> {
+        return List<T>::s_toIndexMap(this);
+    }
+
+    recursive? method transformToIndexMap<V>(vf: recursive? fn(_: T) -> V): Map<Int, V> {
+        return List<T>::s_transformIndexMap<V>[recursive?](this, vf);
+    }
+
+    recursive? method transformToMap<K where KeyType, V>(kf: recursive? fn(_: T) -> K, vf: recursive? fn(_: T) -> V): Map<K, V> {
+        return List<T>::s_transformMap<K, V>[recursive?](this, kf, vf);
+    }
+}
+
+concept ListOf {
+    hidden static s_zip<T, U>(l1: List<T>, l2: List<U>): List<[T, U]> # list_zip
+    hidden static s_unzip<T, U>(l: List<[T, U]>): List<T>, List<U> # list_unzip
+    hidden static s_range(start: Int, end: Int): List<Int> # list_range
+
+    static zip<T, U>(l1: List<T>, l2: List<U>): List<[T, U]>
+        requires release List<T>::s_size(l1) == List<U>::s_size(l2);
+    {
+        return ListOf::s_zip<T, U>(l1, l2);
+    }
+
+    static unzip<T, U>(l: List<[T, U]>): List<T>, List<U> {
+        return ListOf::s_unzip<T, U>(l);
+    }
+
+    static range(start: Int, end: Int): List<Int>
+        requires release start <= end;
+    {
+        return ListOf::s_range(start, end);
+    }
+}

--- a/impl/src/core/verify/map.bsq
+++ b/impl/src/core/verify/map.bsq
@@ -1,0 +1,321 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+//The core namespace implements the primitive concepts used in the bosque core language
+namespace NSCore;
+
+entity Map<K where KeyType, V> provides Object, Expandoable<MapEntry<K, V>>, PODType when K PODType && V PODType, APIType when K APIType && V APIType {
+    hidden static s_size(m: Map<K, V>): Int # map_size
+    hidden static s_has_key(m: Map<K, V>, key: K): Bool # map_has_key
+    hidden static s_at_val(m: Map<K, V>, key: K): V # map_at_val
+
+    hidden static s_key_list(m: Map<K, V>): List<K> # map_key_list
+    hidden static s_key_set(m: Map<K, V>): Set<K> # map_key_set
+    hidden static s_values(m: Map<K, V>): List<V> # map_values
+    hidden static s_entries(m: Map<K, V>): List<MapEntry<K, V>> # map_entries
+
+    hidden static s_has_all(m: Map<K, V>, kl: List<K>): Bool # map_has_all
+    hidden static s_domainincludes(m: Map<K, V>, s: Set<K>): Bool # map_domainincludes
+
+    recursive? hidden static s_submap(m: Map<K, V>, p: recursive? fn(_: K, _: V) -> Bool): Map<K, V> # map_submap
+    hidden static s_oftype<T where KeyType, U>(m: Map<K, V>): Map<T, U> # map_oftype
+    hidden static s_cast<T where KeyType, U>(m: Map<K, V>): Map<T, U> # map_cast
+
+    hidden static s_projectall(m: Map<K, V>, dl: List<K>): Map<K, V> # map_projectall
+    hidden static s_excludeall(m: Map<K, V>, ds: List<K>): Map<K, V> # map_excludeall
+
+    hidden static s_project(m: Map<K, V>, ds: Set<K>): Map<K, V> # map_project
+    hidden static s_exclude(m: Map<K, V>, ds: Set<K>): Map<K, V> # map_exclude
+
+    recursive? hidden static s_remap<U>(m: Map<K, V>, f: recursive? fn(_: K, _: V) -> U): Map<K, U> # map_remap
+
+    hidden static s_composewith<U>(m: Map<K, V>, cm: Map<V, U>): Map<K, U> # map_composewith
+    hidden static s_trycomposewith<U>(m: Map<K, V>, cm: Map<V, U>): Map<K, U?> # map_trycomposewith
+    hidden static s_defaultcomposewith<U>(m: Map<K, V>, cm: Map<V, U>, default: U): Map<K, U> # map_defaultcomposewith
+
+    hidden static {when V KeyType} s_invertinj(m: Map<K, V>): Map<V, K> # map_invertinj
+    hidden static {when V KeyType} s_invertrel(m: Map<K, V>): Map<V, List<K>> # map_invertrel
+
+    hidden static s_union(m: Map<K, V>, om: Map<K, V>): Map<K, V> # map_union
+    hidden static s_unionall(dl: List<Map<K, V>>): Map<K, V> # map_unionall
+
+    hidden static s_merge(m: Map<K, V>, om: Map<K, V>): Map<K, V> # map_merge
+    hidden static s_mergeall(dl: List<Map<K, V>>): Map<K, V> # map_mergeall
+
+    method size(): Int {
+        return Map<K, V>::s_size(this);
+    }
+
+    method empty(): Bool {
+        return Map<K, V>::s_size(this) == 0;
+    }
+
+    method keys(): List<K> {
+        return Map<K, V>::s_key_list(this);
+    }
+
+    method keySet(): Set<K> {
+        return Map<K, V>::s_key_set(this);
+    }
+
+    method values(): List<V> {
+        return Map<K, V>::s_values(this);
+    }
+
+    method entries(): List<MapEntry<K, V>> {
+        return Map<K, V>::s_entries(this);
+    }
+
+    method toDynamicMap(): DynamicMap<K, V> {
+        abort;
+    }
+
+    method has(key: K): Bool {
+        return Map<K, V>::s_has_key(this, key);
+    }
+
+    method hasAll(...kl: List<K>): Bool {
+        return Map<K, V>::s_has_all(this, kl);
+    }
+
+    method domainSubsetOf(s: Set<K>): Bool {
+        if(Set<K>::s_size(s) > Map<K, V>::s_size(this)) {
+            return false;
+        }
+        else {
+            return Map<K, V>::s_domainincludes(this, s);
+        }
+    }
+
+    method get(key: K): V 
+        requires release Map<K, V>::s_has_key(this, key);
+    {
+        return Map<K, V>::s_at_val(this, key);
+    }
+
+    method tryGet(k: K): V? {
+        return Map<K, V>::s_has_key(this, k) ? Map<K, V>::s_at_val(this, k) : none;
+    }
+
+    method defaultGet(k: K, default: V): V {
+        return Map<K, V>::s_has_key(this, k) ? Map<K, V>::s_at_val(this, k) : default;
+    }
+
+    recursive? method submap(p: recursive? fn(_: K, _: V) -> Bool): Map<K, V> {
+        return Map<K, V>::s_submap[recursive?](this, p);
+    }
+
+    method ofType<T where KeyType, U>(): Map<T, U> {
+        return Map<K, V>::s_oftype<T, U>(this);
+    }
+
+    method cast<T where KeyType, U>(): Map<T, U> {
+        return Map<K, V>::s_cast<T, U>(this);
+    }
+
+    method projectAll(...kl: List<K>): Map<K, V> {
+        return Map<K, V>::s_projectall(this, kl);
+    }
+
+    method excludeAll(...kl: List<K>): Map<K, V> {
+        return Map<K, V>::s_excludeall(this, kl);
+    }
+
+    method projectSet(ds: Set<K>): Map<K, V> {
+        return Map<K, V>::s_project(this, ds);
+    }
+
+    method excludeSet(ds: Set<K>): Map<K, V> {
+        return Map<K, V>::s_exclude(this, ds);
+    }
+
+    recursive? method remap<U>(f: recursive? fn(_: K, _: V) -> U): Map<K, U> {
+        return Map<K, V>::s_remap<U>[recursive?](this, f);
+    }
+
+    method {when V KeyType} composeWith<U>(m: Map<V, U>): Map<K, U> {
+        return Map<K, V>::s_composewith<U>(this, m);
+    }
+
+    method {when V KeyType} tryComposeWith<U>(m: Map<V, U>): Map<K, U?> {
+        return Map<K, V>::s_trycomposewith<U>(this, m);
+    }
+
+    method {when V KeyType} defaultComposeWith<U>(m: Map<V, U>, default: U): Map<K, U> {
+        return Map<K, V>::s_defaultcomposewith<U>(this, m, default);
+    }
+
+    method {when V KeyType} invertInjective(): Map<V, K> {
+        return Map<K, V>::s_invertinj(this);
+    }
+
+    method {when V KeyType} invertRelational(): Map<V, List<K>> {
+        return Map<K, V>::s_invertrel(this);
+    }
+
+    method unionWith(m: Map<K, V>): Map<K, V> {
+        return Map<K, V>::s_union(this, m);
+    }
+
+    static unionOf(...ml: List<Map<K, V>>): Map<K, V> {
+        if(List<Map<K, V>>::s_size(ml) == 0) {
+            return Map<K, V>@{};
+        }
+        elif(List<Map<K, V>>::s_size(ml) == 1) {
+            return List<Map<K, V>>::s_unsafe_get(ml, 0);
+        }
+        else {
+            return Map<K, V>::s_unionall(ml);
+        }
+    }
+
+    method mergeWith(m: Map<K, V>): Map<K, V> {
+        return Map<K, V>::s_merge(this, m);
+    }
+
+    static mergeOf(...ml: List<Map<K, V>>): Map<K, V> {
+        if(List<Map<K, V>>::s_size(ml) == 0) {
+            return Map<K, V>@{};
+        }
+        elif(List<Map<K, V>>::s_size(ml) == 1) {
+            return List<Map<K, V>>::s_unsafe_get(ml, 0);
+        }
+        else {
+            return Map<K, V>::s_mergeall(ml);
+        }
+    }
+}
+
+entity DynamicMap<K where KeyType, V> provides Object, Expandoable<MapEntry<K, V>> {
+    method size(): Int {
+        abort;
+    }
+
+    method empty(): Bool  {
+        abort;
+    }
+
+    method keys(): List<K>  {
+        abort;
+    }
+
+    method keySet(): Set<K>  {
+        abort;
+    }
+
+    method values(): List<V>  {
+        abort;
+    }
+
+    method entries(): List<MapEntry<K, V>>  {
+        abort;
+    }
+
+    method toMap(): DynamicMap<K, V> {
+        abort;
+    }
+
+    method has(key: K): Bool {
+        abort;
+    }
+
+    method hasAll(...ks: List<K>): Bool {
+        abort;
+    }
+
+    method domainSubsetOf(s: Set<K>): Bool {
+        abort;
+    }
+
+    method get(key: K): V {
+        abort;
+    }
+
+    method tryGet(k: K): V? {
+        abort;
+    }
+
+    method add(k: K, v: V): DynamicMap<K, V> {
+        abort;
+    }
+
+    method addAll(...el: List<MapEntry<K, V>>): DynamicMap<K, V> {
+        abort;
+    }
+
+    method insert(k: K, v: V): DynamicMap<K, V> {
+        abort;
+    }
+
+    method insertAll(...el: List<MapEntry<K, V>>): DynamicMap<K, V> {
+        abort;
+    }
+
+    method update(k: K, v: V): DynamicMap<K, V> {
+        abort;
+    }
+
+    method updateAll(...el: List<MapEntry<K, V>>): DynamicMap<K, V> {
+        abort;
+    }
+
+    method remove(k: K): DynamicMap<K, V> {
+        abort;
+    }
+
+    method removeAll(...kl: List<K>): DynamicMap<K, V> {
+        abort;
+    }
+
+    recursive? method submap(p: recursive? fn(_: K, _: V) -> Bool): DynamicMap<K, V> {
+        abort;
+    }
+
+    method ofType<T where KeyType, U>(): Map<T, U> {
+        abort;
+    }
+
+    method cast<T where KeyType, U>(): Map<T, U> {
+        abort;
+    }
+
+    method projectAll(...kl: List<K>): DynamicMap<K, V> {
+        abort;
+    }
+
+    method excludeAll(...kl: List<K>): DynamicMap<K, V> {
+        abort;
+    }
+
+    method projectSet(ds: Set<K>): DynamicMap<K, V> {
+        abort;
+    }
+
+    method excludeSet(ds: Set<K>): Map<K, V> {
+        abort;
+    }
+
+    recursive? method remap<U>(f: recursive? fn(_: K, _: V) -> U): DynamicMap<K, U> {
+        abort;
+    }
+
+    method unionWith(m: Map<K, V>): DynamicMap<K, V> {
+        abort;
+    }
+
+    static union(...ml: List<Map<K, V>>): DynamicMap<K, V> {
+        abort;
+    }
+
+    method mergeWith(m: Map<K, V>): DynamicMap<K, V> {
+        abort;
+    }
+
+    static merge(...ml: List<Map<K, V>>): DynamicMap<K, V> {
+        abort;
+    }
+}
+
+

--- a/impl/src/core/verify/queue.bsq
+++ b/impl/src/core/verify/queue.bsq
@@ -1,0 +1,75 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+//The core namespace implements the primitive concepts used in the bosque core language
+namespace NSCore;
+
+entity Queue<T> provides Object, Expandoable<T> {
+    static s_size(q: Queue<T>): Int # queue_size
+
+    method size(): Int {
+        abort;
+    }
+
+    method empty(): Bool {
+        return Queue<T>::s_size(this) == 0;
+    }
+
+    method toList(): List<T> {
+        abort;
+    }
+
+    method dequeue(): T, Queue<T>
+        requires release Queue<T>::s_size(this) != 0;
+    {
+        abort;
+    }
+
+    static idequeue(ref q: Queue<T>): T 
+        requires release Queue<T>::s_size(q) != 0;
+    {
+        abort;
+    }
+
+    method peek(): T
+        requires release Queue<T>::s_size(this) != 0;
+    {
+        abort;
+    }
+
+    method tryPeek(): T? {
+        abort;
+    }
+
+    method lookahead(k: Int): T
+        requires release k < Queue<T>::s_size(this);
+    {
+        abort;
+    }
+
+    method tryLookahead(k: Int): T? {
+        abort;
+    }
+
+    method rest(): Queue<T>
+        requires release Queue<T>::s_size(this) != 0;
+    {
+        abort;
+    }
+
+    static irest(ref q: Queue<T>)
+        requires release Queue<T>::s_size(q) != 0;
+    {
+       abort;
+    }
+
+    method enqueue(v: T): Queue<T> {
+        abort;
+    }
+
+    static ienqueue(ref q: Queue<T>, v: T) {
+       abort;
+    }
+}

--- a/impl/src/core/verify/set.bsq
+++ b/impl/src/core/verify/set.bsq
@@ -1,0 +1,218 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+//The core namespace implements the primitive concepts used in the bosque core language
+namespace NSCore;
+
+entity Set<T where KeyType> provides Object, Expandoable<T>, PODType when T PODType, APIType when T APIType {
+    hidden static s_size(s: Set<T>): Int # set_size
+
+    hidden static s_entry_list(s: Set<T>): List<T> # set_entry_list
+
+    hidden static s_has_key(s: Set<T>, v: T): Bool # set_has_key
+    hidden static s_hasall(s: Set<T>, l: List<T>): Bool # set_hasall
+    
+    hidden static s_subsetof(s: Set<T>, os: Set<T>): Bool # set_subsetof
+    hidden static s_equal(s: Set<T>, os: Set<T>): Bool # set_equal
+    hidden static s_disjoint(s: Set<T>, os: Set<T>): Bool # set_disjoint
+
+    recursive? hidden static s_subset(s: Set<T>, p: recursive? fn(_: T) -> Bool): Set<T> # set_subset
+    hidden static s_oftype<U where KeyType>(s: Set<T>): Set<U> # set_oftype
+    hidden static s_cast<U where KeyType>(s: Set<T>): Set<U> # set_cast
+
+    hidden static s_union(s: Set<T>, os: Set<T>): Set<T> # set_union
+    hidden static s_intersect(s: Set<T>, os: Set<T>): Set<T> # set_intersect
+    hidden static s_difference(s: Set<T>, os: Set<T>): Set<T> # set_difference
+    hidden static s_symmetricdifference(s: Set<T>, os: Set<T>): Set<T> # set_symmetricdifference
+
+    hidden static s_unionall(sl: List<Set<T>>): Set<T> # set_unionall
+    hidden static s_intersectall(sl: List<Set<T>>): Set<T> # set_intersectall
+
+    method size(): Int {
+        return Set<T>::s_size(this);
+    }
+
+    method empty(): Bool {
+        return Set<T>::s_size(this) == 0;
+    }
+
+    method entries(): List<T> {
+        return Set<T>::s_entry_list(this);
+    }
+
+    method has(v: T): Bool {
+        return Set<T>::s_has_key(this, v);
+    }
+
+    method hasAll(...v: List<T>): Bool {
+        return Set<T>::s_hasall(this, v);
+    }
+
+    method toDynamicSet<T>(): DynamicSet<T> {
+        abort;
+    }
+
+    method subsetOf(s: Set<T>): Bool {
+        return Set<T>::s_subsetof(this, s);
+    }
+
+    method equal(s: Set<T>): Bool {
+        return Set<T>::s_equal(this, s);
+    }
+
+    method disjoint(s: Set<T>): Bool {
+        return Set<T>::s_disjoint(this, s);
+    }
+
+    recursive? method subset(p: recursive? fn(_: T) -> Bool): Set<T> {
+        return Set<T>::s_subset[recursive?](this, p);
+    }
+
+    method ofType<U where KeyType>(): Set<U> {
+        return Set<T>::s_oftype<U>(this);
+    }
+
+    method cast<U where KeyType>(): Set<U> {
+        return Set<T>::s_cast<U>(this);
+    }
+
+    method union(s: Set<T>): Set<T> {
+        return Set<T>::s_union(this, s);
+    }
+
+    method intersect(s: Set<T>): Set<T> {
+        return Set<T>::s_intersect(this, s);
+    }
+
+    method difference(s: Set<T>): Set<T> {
+        return Set<T>::s_difference(this, s);
+    }
+
+    method symmetricDifference(s: Set<T>): Set<T> {
+       return Set<T>::s_symmetricdifference(this, s);
+    }
+
+    static unionOf(...sl: List<Set<T>>): Set<T> {
+        if(List<T>::s_size(sl) == 0) {
+            return Set<T>@{};
+        }
+        elif(List<T>::s_size(sl) == 1) {
+            return List<T>::s_unsafe_get(sl, 0);
+        }
+        else {
+            return Set<T>::s_unionall(sl);
+        }
+    }
+
+    static intersectionOf(...sl: List<Set<T>>): Set<T> {
+        if(List<T>::s_size(sl) == 0) {
+            return Set<T>@{};
+        }
+        elif(List<T>::s_size(sl) == 1) {
+            return List<T>::s_unsafe_get(sl, 0);
+        }
+        else {
+            return Set<T>::s_intersectall(sl);
+        }
+    }
+}
+
+entity DynamicSet<T where KeyType> provides Object, Expandoable<T> {
+    method size(): Int {
+        abort;
+    }
+
+    method empty(): Bool {
+        abort;
+    }
+
+    method entries(): List<T> {
+        abort;
+    }
+
+    method has(v: T): Bool  {
+        abort;
+    }
+
+    method hasAll(...v: List<T>): Bool  {
+        abort;
+    }
+
+    method toSet<T>(): Set<T> {
+        abort;
+    }
+
+    method add(v: T): DynamicSet<T>  {
+        abort;
+    }
+
+    method addAll(...v: List<T>): DynamicSet<T>  {
+        abort;
+    }
+
+    method insert(v: T): DynamicSet<T>  {
+        abort;
+    }
+
+    method insertAll(...v: List<T>): DynamicSet<T>  {
+        abort;
+    }
+
+    method remove(v: T): DynamicSet<T>  {
+        abort;
+    }
+
+    method removeAll(...v: List<T>): DynamicSet<T>  {
+        abort;
+    }
+
+    method subsetOf(s: DynamicSet<T>): Bool  {
+        abort;
+    }
+
+    method equal(s: DynamicSet<T>): Bool  {
+        abort;
+    }
+
+    method disjoint(s: DynamicSet<T>): Bool  {
+        abort;
+    }
+
+    recursive? method subset(p: recursive? fn(_: T) -> Bool): Set<T> {
+        abort;
+    }
+
+    method ofType<U where KeyType>(): Set<U> {
+        abort;
+    }
+
+    method cast<U where KeyType>(): Set<U> {
+        abort;
+    }
+
+    method union(s: DynamicSet<T>): DynamicSet<T>  {
+        abort;
+    }
+
+    method intersect(s: DynamicSet<T>): DynamicSet<T>  {
+        abort;
+    }
+
+    method difference(s: DynamicSet<T>): DynamicSet<T>  {
+        abort;
+    }
+
+    method symmetricDifference(s: DynamicSet<T>): DynamicSet<T>  {
+        abort;
+    }
+
+    static unionOf(...sl: List<DynamicSet<T>>): DynamicSet<T> {
+        abort;
+    }
+
+    static intersectionOf(...sl: List<DynamicSet<T>>): DynamicSet<T> {
+        abort;
+    }
+}

--- a/impl/src/core/verify/stack.bsq
+++ b/impl/src/core/verify/stack.bsq
@@ -1,0 +1,75 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+//The core namespace implements the primitive concepts used in the bosque core language
+namespace NSCore;
+
+entity Stack<T> provides Object, Expandoable<T> {
+    static s_size(s: Stack<T>): Int # stack_size
+
+    method size(): Int {
+       abort;
+    }
+
+    method empty(): Bool {
+        abort;
+    }
+
+    method toList(): List<T> {
+        abort;
+    }
+
+    method pop(): T, Stack<T>
+        requires release Stack<T>::s_size(this) != 0;
+    {
+        abort;
+    }
+
+    static ipop(ref s: Stack<T>): T 
+        requires release Stack<T>::s_size(s) != 0;
+    {
+        abort;
+    }
+
+    method peek(): T
+        requires release Stack<T>::s_size(this) != 0;
+    {
+        abort;
+    }
+
+    method tryPeek(): T? {
+        abort;
+    }
+
+    method lookahead(k: Int): T
+        requires release k < Stack<T>::s_size(this);
+    {
+        abort;
+    }
+
+    method tryLookahead(k: Int): T? {
+        abort;
+    }
+
+    method rest(): Stack<T> 
+        requires release Stack<T>::s_size(this) != 0;
+    {
+        abort;
+    }
+
+    static irest(ref s: Stack<T>)
+        requires release Stack<T>::s_size(s) != 0;
+    {
+        abort;
+    }
+
+    method push(v: T): Stack<T> {
+        abort;
+    }
+
+    static ipush(ref s: Stack<T>, v: T) {
+        abort;
+    }
+}

--- a/impl/src/runtimes/symtest/symtest.ts
+++ b/impl/src/runtimes/symtest/symtest.ts
@@ -66,6 +66,7 @@ function generateMASM(files: string[], corelibpath: string): MIRAssembly {
 Commander
     .option("-e --entrypoint [entrypoint]", "Entrypoint to symbolically test", "NSMain::main")
     .option("-m --model", "Try to get model for failing inputs", false)
+    .option("-v --verify", "Run verifier instead of symbolic testing", false)
     .option("-o --output [file]", "Output the model to a given file");
 
 Commander.parse(process.argv);
@@ -76,7 +77,7 @@ if (Commander.args.length === 0) {
 }
 
 process.stdout.write(`Symbolic testing of Bosque sources in files:\n${Commander.args.join("\n")}\n...\n`);
-const massembly = generateMASM(Commander.args, "symbolic");
+const massembly = generateMASM(Commander.args, Commander.verify ? "verify" : "symbolic");
 
 setImmediate(() => {
     process.stdout.write(`Transpiling Bosque assembly to bytecode with entrypoint of ${Commander.entrypoint}...\n`);
@@ -94,7 +95,7 @@ setImmediate(() => {
             process.exit(1);
         }
 
-        const sparams = SMTEmitter.emit(massembly, entrypoint, true);
+        const sparams = SMTEmitter.emit(massembly, entrypoint, true, Commander.verify);
         const lsrc = FS.readFileSync(smt_runtime).toString();
         const contents = lsrc
             .replace(";;NOMINAL_DECLS_FWD;;", sparams.NOMINAL_DECLS_FWD)

--- a/impl/src/runtimes/vscmd/vscmd.ts
+++ b/impl/src/runtimes/vscmd/vscmd.ts
@@ -198,7 +198,7 @@ function verify(masm: MIRAssembly, config: any, genmodel: boolean): [boolean, bo
             return [false, false];
         }
 
-        const sparams = SMTEmitter.emit(masm, entrypoint, true);
+        const sparams = SMTEmitter.emit(masm, entrypoint, true, false);
         const lsrc = FS.readFileSync(smt_runtime).toString();
         const contents = lsrc
             .replace(";;NOMINAL_DECLS_FWD;;", sparams.NOMINAL_DECLS_FWD)

--- a/impl/src/test/runner.ts
+++ b/impl/src/test/runner.ts
@@ -84,7 +84,7 @@ else if ((Commander.symbolic || Commander.result) !== undefined) {
             process.exit(1);
         }
 
-        const sparams = SMTEmitter.emit(massembly, entrypoint, Commander.symbolic !== undefined);
+        const sparams = SMTEmitter.emit(massembly, entrypoint, Commander.symbolic !== undefined, false);
         const lsrc = FS.readFileSync(smt_runtime).toString();
         const contents = lsrc
         .replace(";;NOMINAL_DECLS_FWD;;", sparams.NOMINAL_DECLS_FWD)


### PR DESCRIPTION
Changes:
`symtest` now supports a `--verify` option which replaces bounded symbolic testing with full verification using uninterpreted functions and axioms.

This PR mainly hooks up the right code and a default way to generate all the used uninterpreted functions but only has a few sample axioms so it isn't going to do a lot just yet. 
