### PR TITLE
implemented map's add() method

### DIFF
--- a/impl/src/core/cpp/map.bsq
+++ b/impl/src/core/cpp/map.bsq
@@ -15,6 +15,7 @@ entity Map<K where KeyType, V> provides Object, Expandoable<MapEntry<K, V>>, POD
     hidden static s_key_set(m: Map<K, V>): Set<K> # map_key_set
     hidden static s_values(m: Map<K, V>): List<V> # map_values
     hidden static s_entries(m: Map<K, V>): List<MapEntry<K, V>> # map_entries
+    hidden static s_add(m: Map<K, V>, k: K, v: V): Map<K, V> #map_add
 
     hidden static s_has_all(m: Map<K, V>, kl: List<K>): Bool # map_has_all
     hidden static s_domainincludes(m: Map<K, V>, s: Set<K>): Bool # map_domainincludes
@@ -101,6 +102,10 @@ entity Map<K where KeyType, V> provides Object, Expandoable<MapEntry<K, V>>, POD
 
     method defaultGet(k: K, default: V): V {
         return Map<K, V>::s_has_key(this, k) ? Map<K, V>::s_at_val(this, k) : default;
+    }
+
+    method add(k: K, v: V): Map<K, V> {
+     return Map<K, V>::s_add(this, k, v);
     }
 
     recursive? method submap(p: recursive? fn(_: K, _: V) -> Bool): Map<K, V> {

--- a/impl/src/test/tests/library/maptests.bsq
+++ b/impl/src/test/tests/library/maptests.bsq
@@ -330,3 +330,11 @@ entrypoint function mergeop(): Int {
 
     return 0;
 }
+
+entrypoint function addop(): Int {
+    let m1 = Map<Int, String>@{1 => "a", 2 => "b"};
+    let m2 = m1.add(3, "c");
+    check m2.size() == 3;
+    check m2.get(2) == "c";
+    return 0;
+}

--- a/impl/src/test/tests/library/test.json
+++ b/impl/src/test/tests/library/test.json
@@ -254,6 +254,11 @@
                 "kind": "symexec",
                 "entrypoint": "mergeop",
                 "expected": "0"
+            },
+            {
+                "kind": "symexec",
+                "entrypoint": "addop",
+                "expected": "0"
             }
         ]
     },

--- a/impl/src/tooling/aot/cppbody_emitter.ts
+++ b/impl/src/tooling/aot/cppbody_emitter.ts
@@ -2856,6 +2856,16 @@ class CPPBodyEmitter {
                 bodystr = `auto $$return = ${this.createMapOpsFor(mtype, ktype, vtype)}::map_mergeall<${ltyperepr.base}, MIRNominalTypeEnum::${this.typegen.mangleStringForCpp(rtype.trkey)}, ${kops.inc}, ${vops.inc}>(${params[0]});`;
                 break;
             }
+            case "map_add": {
+                const mtype = this.getEnclosingMapTypeForMapOp(idecl);
+                const ktype = this.getMapKeyContentsInfoForMapOp(idecl);
+                const kops = this.typegen.getFunctorsForType(ktype);
+                const vtype = this.getMapValueContentsInfoForMapOp(idecl);
+                const vops = this.typegen.getFunctorsForType(vtype);
+
+                bodystr = `auto $$return = ${this.createMapOpsFor(mtype, ktype, vtype)}::map_add<${kops.inc}, ${vops.inc}>(${params[0]}, ${params[1]}, ${params[2]});`;
+                break;
+            }
             case "iteration_while": {
                 assert(false, `Need to implement -- ${idecl.iname}`);
                 break;

--- a/impl/src/tooling/aot/runtime/bsqcustom/bsqmap_ops.h
+++ b/impl/src/tooling/aot/runtime/bsqcustom/bsqmap_ops.h
@@ -13,6 +13,19 @@ template <typename Ty, typename K, typename K_RCDecF, typename K_DisplayF, typen
 class BSQMapOps
 {
 public:
+    template <typename K_RCIncF, typename V_RCIncF>
+    static Ty* map_add(Ty* m, K k, V v)
+    {
+        std::vector<MEntry<K, V>> entries;
+        entries.reserve(m->entries.size());
+
+        for (const auto& [key, value] : m->entries) {
+            entries.push_back(MEntry<K, V>{K_RCIncF{}(key), V_RCIncF{}(value)});
+        }
+        entries.emplace_back(MEntry<K, V>{K_RCIncF{}(k), V_RCIncF{}(v)});
+        return BSQ_NEW_NO_RC(Ty, m->nominalType, move(entries));
+    }
+
     template <typename ListT, typename K_RCIncF, MIRNominalTypeEnum ntype>
     static ListT* map_key_list(Ty* m)
     {


### PR DESCRIPTION
Fixes https://github.com/microsoft/BosqueLanguage/issues/342

Changes:
This PR adds an implementation of Map<K,V> `add` method. Test included.

However: _although it seems to be fixing this issue, there are important **language design reasons** which could render it obsolete_.

