### PR TITLE
Set the filetype key in bosque.tmLanguage.json

### DIFF
--- a/bosque-language-tools/syntaxes/bosque.tmLanguage.json
+++ b/bosque-language-tools/syntaxes/bosque.tmLanguage.json
@@ -1,5 +1,8 @@
 {
 	"name": "Bosque",
+	"fileTypes": [
+	    "bsq"
+	],
 	"patterns": [
 		{
 			"include": "#comments"


### PR DESCRIPTION
**Changes:**
Perhaps we could specify the most common Bosque file type `bsq`
