### PR TITLE
Fix: missing float64_parse implementation

### DIFF
--- a/impl/src/tooling/aot/cppbody_emitter.ts
+++ b/impl/src/tooling/aot/cppbody_emitter.ts
@@ -1863,7 +1863,7 @@ class CPPBodyEmitter {
                 break;
             }
             case "float64_parse": {
-                bodystr = `auto $$return = (double)std::stod(${params[0]}.sdata);`;
+                bodystr = `auto $$return = (double)std::stod(${params[0]}->sdata);`;
                 break;
             }
             case "float_toint": {

--- a/impl/src/tooling/aot/cppbody_emitter.ts
+++ b/impl/src/tooling/aot/cppbody_emitter.ts
@@ -1863,7 +1863,7 @@ class CPPBodyEmitter {
                 break;
             }
             case "float64_parse": {
-                bodystr = `auto $$return = (double)stod(${params[0]});`;
+                bodystr = `auto $$return = (double)std::stod(${params[0]});`;
                 break;
             }
             case "float_toint": {

--- a/impl/src/tooling/aot/cppbody_emitter.ts
+++ b/impl/src/tooling/aot/cppbody_emitter.ts
@@ -1863,7 +1863,7 @@ class CPPBodyEmitter {
                 break;
             }
             case "float64_parse": {
-                bodystr = `auto $$return = std::stod(${params[0]});`;
+                bodystr = `auto $$return = (double)stod(${params[0]});`;
                 break;
             }
             case "float_toint": {

--- a/impl/src/tooling/aot/cppbody_emitter.ts
+++ b/impl/src/tooling/aot/cppbody_emitter.ts
@@ -1863,7 +1863,7 @@ class CPPBodyEmitter {
                 break;
             }
             case "float64_parse": {
-                bodystr = `auto $$return = (double)std::stod(${params[0]});`;
+                bodystr = `auto $$return = (double)std::stod(${params[0]}.sdata);`;
                 break;
             }
             case "float_toint": {

--- a/impl/src/tooling/aot/cppbody_emitter.ts
+++ b/impl/src/tooling/aot/cppbody_emitter.ts
@@ -1863,7 +1863,7 @@ class CPPBodyEmitter {
                 break;
             }
             case "float64_parse": {
-                bodystr = `auto $$return = ;`;
+                bodystr = `auto $$return = std::stod(${params[0]});`;
                 break;
             }
             case "float_toint": {


### PR DESCRIPTION
I tried to use the `Parse64::parse()` static method to parse arguments received from an Entrypoint, but I found error messages. 

So I discovered missing implementations in the cppbody_emitter. I'm not sure if this is an implementation aligned with the Bosque Roadmap, but it works.

I made this pull request to receive feedback about this proposal for performing this function.

TODO: Test cases